### PR TITLE
Add Qt to the RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,27 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${QT_LIB_DIR}")
 
 add_definitions(-DQT5)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)   # set location for all executables in the build folder
+
+option(USE_STANDARD_INSTALLATION_LOCATION "Use standard GNU installation locations" OFF)
+
+if (USE_STANDARD_INSTALLATION_LOCATION)
+    include(GNUInstallDirs)    # for standard installation locations
+    set(PLUGIN_INSTALLATION_PATH ${CMAKE_INSTALL_LIBDIR}/dlt-viewer/plugins)
+    set(RESOURCE_INSTALLATION_PATH ${CMAKE_INSTALL_DATADIR}/dlt-viewer)
+    set(EXECUTABLE_INSTALLATION_PATH ${CMAKE_INSTALL_BINDIR})
+    set(LIBRARY_INSTALLATION_PATH ${CMAKE_INSTALL_LIBDIR})
+else()
+    set(PLUGIN_INSTALLATION_PATH deploy/plugins)
+    set(RESOURCE_INSTALLATION_PATH deploy)
+    set(EXECUTABLE_INSTALLATION_PATH deploy)
+    set(LIBRARY_INSTALLATION_PATH deploy)
+endif()
+
+file(RELATIVE_PATH PLUGIN_RELATIVE_PATH /${EXECUTABLE_INSTALLATION_PATH} /${PLUGIN_INSTALLATION_PATH})
+add_definitions(-DPLUGIN_RELATIVE_PATH=${PLUGIN_RELATIVE_PATH})
+
+
 add_subdirectory(parser)
 add_subdirectory(qdlt)
 add_subdirectory(qextserialport)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ set (CMAKE_AUTOUIC ON)
 
 set (CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Add Qt to the RPATH, so that there is no need to set LD_LIBRARY_PATH at runtime if Qt is installed in a non-standard location
+get_target_property(QT_LIBRARY_PATH Qt5::Core LOCATION)
+get_filename_component(QT_LIB_DIR ${QT_LIBRARY_PATH} DIRECTORY)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${QT_LIB_DIR}")
+
 add_definitions(-DQT5)
 
 add_subdirectory(parser)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -28,4 +28,4 @@ add_executable(dlt_parser main.cpp
 
 target_link_libraries(dlt_parser Qt5::Widgets )
 
-install(TARGETS dlt_parser DESTINATION deploy)
+install(TARGETS dlt_parser DESTINATION ${EXECUTABLE_INSTALLATION_PATH})

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -17,6 +17,20 @@
 cmake_minimum_required (VERSION 2.8.12)
 set (CMAKE_VERBOSE_MAKEFILE FALSE)
 
+function(add_plugin NAME)
+
+    target_link_libraries(${NAME} qdlt Qt5::Widgets)
+    install(TARGETS ${NAME} DESTINATION ${PLUGIN_INSTALLATION_PATH})
+
+    # set the location of the plugins in such a way that they can be located by the dlt-viewer executable when running in 
+    # directly from the build folder (without "make install")
+    set_target_properties(${NAME} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PLUGIN_RELATIVE_PATH}
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PLUGIN_RELATIVE_PATH}
+    )
+
+endfunction()
+
 add_subdirectory(dltviewerplugin)
 add_subdirectory(nonverboseplugin)
 add_subdirectory(filetransferplugin)
@@ -27,3 +41,4 @@ add_subdirectory(dummycommandplugin)
 add_subdirectory(dummydecoderplugin)
 add_subdirectory(dltdbusplugin)
 add_subdirectory(dltlogstorageplugin)
+

--- a/plugin/dltdbusplugin/CMakeLists.txt
+++ b/plugin/dltdbusplugin/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(dltdbusplugin MODULE dltdbusplugin.cpp
 
 target_link_libraries(dltdbusplugin qdlt Qt5::Widgets )
 
-install(TARGETS dltdbusplugin DESTINATION deploy/plugins)
+add_plugin(dltdbusplugin)

--- a/plugin/dltlogstorageplugin/CMakeLists.txt
+++ b/plugin/dltlogstorageplugin/CMakeLists.txt
@@ -24,4 +24,4 @@ add_library(dltlogstorageplugin MODULE dltlogstorageconfigcreatorplugin.cpp
     ${UI_HEADERS})
 
 target_link_libraries(dltlogstorageplugin qdlt Qt5::Widgets )
-install(TARGETS dltlogstorageplugin DESTINATION deploy/plugins)
+add_plugin(dltlogstorageplugin)

--- a/plugin/dltsystemviewerplugin/CMakeLists.txt
+++ b/plugin/dltsystemviewerplugin/CMakeLists.txt
@@ -22,5 +22,4 @@ add_library(dltsystemviewerplugin MODULE dltsystemviewerplugin.cpp
     				form.cpp
                           	${UI_HEADERS})
 
-target_link_libraries(dltsystemviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dltsystemviewerplugin DESTINATION deploy/plugins)
+add_plugin(dltsystemviewerplugin)

--- a/plugin/dltviewerplugin/CMakeLists.txt
+++ b/plugin/dltviewerplugin/CMakeLists.txt
@@ -25,5 +25,4 @@ add_library(dltviewerplugin MODULE dltviewerplugin.cpp
 				form.cpp
 	                        ${UI_HEADERS})
 
-target_link_libraries(dltviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dltviewerplugin DESTINATION deploy/plugins)
+add_plugin(dltviewerplugin)

--- a/plugin/dummycommandplugin/CMakeLists.txt
+++ b/plugin/dummycommandplugin/CMakeLists.txt
@@ -25,5 +25,4 @@
 add_library(dummycommandplugin MODULE dummycommandplugin.cpp
 	                        ${UI_HEADERS})
 
-target_link_libraries(dummycommandplugin qdlt Qt5::Widgets )
-install(TARGETS dummycommandplugin DESTINATION deploy/plugins)
+add_plugin(dummycommandplugin)

--- a/plugin/dummycontrolplugin/CMakeLists.txt
+++ b/plugin/dummycontrolplugin/CMakeLists.txt
@@ -24,5 +24,4 @@ add_library(dummycontrolplugin MODULE dummycontrolplugin.cpp
    form.cpp
    ${UI_HEADERS})
 
-target_link_libraries(dummycontrolplugin qdlt Qt5::Widgets )
-install(TARGETS dummycontrolplugin DESTINATION deploy/plugins)
+add_plugin(dummycontrolplugin)

--- a/plugin/dummydecoderplugin/CMakeLists.txt
+++ b/plugin/dummydecoderplugin/CMakeLists.txt
@@ -21,5 +21,4 @@
 add_library(dummydecoderplugin MODULE dummydecoderplugin.cpp
                         ${UI_HEADERS})
 
-target_link_libraries(dummydecoderplugin qdlt Qt5::Widgets )
-install(TARGETS dummydecoderplugin DESTINATION deploy/plugins)
+add_plugin(dummydecoderplugin)

--- a/plugin/dummyviewerplugin/CMakeLists.txt
+++ b/plugin/dummyviewerplugin/CMakeLists.txt
@@ -22,5 +22,4 @@ add_library(dummyviewerplugin MODULE dummyviewerplugin.cpp
     				form.cpp
                           	${UI_HEADERS})
 
-target_link_libraries(dummyviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dummyviewerplugin DESTINATION deploy/plugins)
+add_plugin(dummyviewerplugin)

--- a/plugin/filetransferplugin/CMakeLists.txt
+++ b/plugin/filetransferplugin/CMakeLists.txt
@@ -30,6 +30,5 @@ add_library(filetransferplugin 	MODULE filetransferplugin.cpp
 				configuration.cpp
 				${UI_HEADERS})
 
-target_link_libraries(filetransferplugin qdlt Qt5::Widgets Qt5::PrintSupport )
-
-install(TARGETS filetransferplugin DESTINATION deploy/plugins)
+target_link_libraries(filetransferplugin Qt5::PrintSupport )
+add_plugin(filetransferplugin)

--- a/plugin/nonverboseplugin/CMakeLists.txt
+++ b/plugin/nonverboseplugin/CMakeLists.txt
@@ -21,6 +21,4 @@
 add_library(nonverboseplugin MODULE nonverboseplugin.cpp
                           ${UI_HEADERS})
 
-target_link_libraries(nonverboseplugin qdlt Qt5::Widgets )
-
-install(TARGETS nonverboseplugin DESTINATION deploy/plugins)
+add_plugin(nonverboseplugin)

--- a/qdlt/CMakeLists.txt
+++ b/qdlt/CMakeLists.txt
@@ -37,4 +37,4 @@ target_include_directories (qdlt  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 
 target_link_libraries(qdlt Qt5::Core Qt5::Network)
 
-install(TARGETS qdlt DESTINATION deploy)
+install(TARGETS qdlt DESTINATION ${LIBRARY_INSTALLATION_PATH})

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -6,6 +6,10 @@
 //#include <QMessageBox>
 #include <QTextStream>
 #include <QString>
+#include <QDebug>
+
+#define STRINGIFY(a) str(a)
+#define str(a) #a
 
 QDltPluginManager::QDltPluginManager()
 {
@@ -33,8 +37,10 @@ QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
     QDir pluginsDir;
     QStringList errorStrings;
     /* The viewer looks in the relativ to the executable in the ./plugins directory */
-    pluginsDir.setPath(QCoreApplication::applicationDirPath());
-    if(pluginsDir.cd("plugins"))
+    QString defaultPluginPath = QCoreApplication::applicationDirPath() + QDir::separator() + STRINGIFY(PLUGIN_RELATIVE_PATH);
+
+    pluginsDir.setPath(defaultPluginPath);
+    if(pluginsDir.exists())
     {
         errorStrings << loadPluginsPath(pluginsDir);
     }
@@ -47,13 +53,6 @@ QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
         {
             errorStrings << loadPluginsPath(pluginsDir);
         }
-    }
-
-    /* Load plugins from system directory in linux */
-    pluginsDir.setPath("/usr/share/dlt-viewer/plugins");
-    if(pluginsDir.exists() && pluginsDir.isReadable())
-    {
-        errorStrings << loadPluginsPath(pluginsDir);
     }
 
     return errorStrings;

--- a/qextserialport/CMakeLists.txt
+++ b/qextserialport/CMakeLists.txt
@@ -38,4 +38,4 @@ target_include_directories (qextserialport PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 qt5_use_modules(qextserialport Core)
 
-install(TARGETS qextserialport DESTINATION deploy)
+install(TARGETS qextserialport DESTINATION ${LIBRARY_INSTALLATION_PATH})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,6 @@ target_link_libraries(dlt-viewer  qdlt
                                   ${Qt5Widgets_LIBRARIES}
                                   ${Qt5SerialPort_LIBRARIES})
 
-install(TARGETS dlt-viewer DESTINATION deploy)
-install(DIRECTORY icon png svg DESTINATION deploy
+install(TARGETS dlt-viewer DESTINATION ${EXECUTABLE_INSTALLATION_PATH})
+install(DIRECTORY icon png svg DESTINATION ${RESOURCE_INSTALLATION_PATH}
 			PATTERN icon/*.rc EXCLUDE )

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4889,6 +4889,8 @@ void MainWindow::loadPlugins()
 
       PluginItem* item = new PluginItem(0,plugin);
 
+      qDebug() << "Loaded plugin: " << plugin->getName();
+
       plugin->setMode((QDltPlugin::Mode) DltSettingsManager::getInstance()->value("plugin/pluginmodefor"+plugin->getName(),QVariant(QDltPlugin::ModeDisable)).toInt());
 
       if(plugin->isViewer())


### PR DESCRIPTION
Add Qt to the RPATH, so that there is no need to set LD_LIBRARY_PATH at
runtime if Qt is installed in a non-standard location