### PR TITLE
Fix build on OS X, support HiDPI displays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ cmake_minimum_required (VERSION 2.8.12)
 
 project (DLT-Viewer)
 
+set(CMAKE_CXX_STANDARD 11)
 
 set(QT_VERSION_REQ "5")
 

--- a/qextserialport/CMakeLists.txt
+++ b/qextserialport/CMakeLists.txt
@@ -25,13 +25,21 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
     list(APPEND QEXT_SERIALPORT_SOURCES src/qextserialport_unix.cpp
                                         src/qextserialenumerator_unix.cpp)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)  # OSX
-    list(APPEND QEXT_SERIALPORT_SOURCES src/qextserialenumerator_osx.cpp)
+    find_library(IOKIT_LIBRARY IOKit)
+    find_library(FOUNDATION_LIBRARY Foundation)
+    list(APPEND QEXT_SERIALPORT_SOURCES src/qextserialport_unix.cpp
+                                        src/qextserialenumerator_osx.cpp)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Windows)
     list(APPEND QEXT_SERIALPORT_SOURCES src/qextserialport_win.cpp
                                         src/qextserialenumerator_win.cpp)
 endif()
 
 add_library (qextserialport ${QEXT_SERIALPORT_SOURCES})
+if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+    target_link_libraries(qextserialport
+        ${IOKIT_LIBRARY}
+        ${FOUNDATION_LIBRARY})
+endif()
 # Make sure the compiler can find include files for our qextserialport library
 # when other libraries or executables link to qextserialport
 target_include_directories (qextserialport PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,11 @@
 
 int main(int argc, char *argv[])
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
     QApplication a(argc, argv);
 
     QStringList arguments = a.arguments();


### PR DESCRIPTION
These patches fix the build of current dlt-viewer on macOS and improve rendering on HiDPI screens such as retina displays.