### PR TITLE
tablemodel: fix deprecated Qt class

### DIFF
--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -358,7 +358,7 @@ QColor TableModel::searchBackgroundColor() const
 
 void HtmlDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QStyleOptionViewItemV4 optionV4 = option;
+    QStyleOptionViewItem optionV4 = option;
     initStyleOption(&optionV4, index);
 
     QStyle *style = optionV4.widget? optionV4.widget->style() : QApplication::style();
@@ -387,7 +387,7 @@ void HtmlDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
 
 QSize HtmlDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QStyleOptionViewItemV4 optionV4 = option;
+    QStyleOptionViewItem optionV4 = option;
     initStyleOption(&optionV4, index);
 
     QTextDocument doc;


### PR DESCRIPTION
QStyleOptionViewItemV4 is deprecated as of Qt 5.7.

dlt-viewer/src/tablemodel.cpp:361:28: warning: ‘QStyleOptionViewItemV4’ is deprecated [-Wdeprecated-declarations]
     QStyleOptionViewItemV4 optionV4 = option;

dlt-viewer/src/tablemodel.cpp:390:28: warning: ‘QStyleOptionViewItemV4’ is deprecated [-Wdeprecated-declarations]
     QStyleOptionViewItemV4 optionV4 = option;

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>