### PR TITLE
Start ColorDialog with current color instead of white

### DIFF
--- a/src/filterdialog.cpp
+++ b/src/filterdialog.cpp
@@ -307,7 +307,7 @@ bool FilterDialog::getEnableMarker(){
 
 void FilterDialog::on_buttonSelectColor_clicked()
 {
-    QColor selectedBackgroundColor = QColorDialog::getColor();
+    QColor selectedBackgroundColor = QColorDialog::getColor(this->getFilterColour());
     if(selectedBackgroundColor.isValid())
     {
         this->setFilterColour(selectedBackgroundColor);


### PR DESCRIPTION
This patch makes the color selector start with the current filter color to modify in the color picker dialog instead of the default white color. It makes it easier to adjust the filter color if it is too similar to one already used.