### PR TITLE
Fix duplicate symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gitconfig
+CMakeLists.txt.user
 *.pro.user
 build/
 .project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ get_target_property(QT_LIBRARY_PATH Qt5::Core LOCATION)
 get_filename_component(QT_LIB_DIR ${QT_LIBRARY_PATH} DIRECTORY)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${QT_LIB_DIR}")
 
+# build executables in build/bin directory
+set(BIN_DIR ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BIN_DIR})
+
 add_definitions(-DQT5)
 
 add_subdirectory(parser)

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -17,6 +17,13 @@
 cmake_minimum_required (VERSION 2.8.12)
 set (CMAKE_VERBOSE_MAKEFILE FALSE)
 
+# build plugins in build/bin/plugins directory
+set(PLUGIN_DIR ${BIN_DIR}/plugins)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PLUGIN_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PLUGIN_DIR})
+
+
 add_subdirectory(dltviewerplugin)
 add_subdirectory(nonverboseplugin)
 add_subdirectory(filetransferplugin)

--- a/plugin/dltdbusplugin/dltdbusplugin.cpp
+++ b/plugin/dltdbusplugin/dltdbusplugin.cpp
@@ -249,7 +249,7 @@ QWidget* DltDBusPlugin::initViewer()
 {
     // also called when plugin not activated
 
-    form = new Form();
+    form = new DltDbus::Form();
     return form;
 }
 

--- a/plugin/dltdbusplugin/dltdbusplugin.h
+++ b/plugin/dltdbusplugin/dltdbusplugin.h
@@ -122,7 +122,7 @@ public:
     bool decodeMsg(QDltMsg &msg, int triggeredByUser);
 
     /* internal variables */
-    Form *form;
+    DltDbus::Form *form;
 
 private:
 

--- a/plugin/dltdbusplugin/form.cpp
+++ b/plugin/dltdbusplugin/form.cpp
@@ -20,6 +20,8 @@
 #include "form.h"
 #include "ui_form.h"
 
+using namespace DltDbus;
+
 Form::Form(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Form)

--- a/plugin/dltdbusplugin/form.h
+++ b/plugin/dltdbusplugin/form.h
@@ -22,6 +22,7 @@
 
 #include <QWidget>
 
+namespace DltDbus {
 namespace Ui {
     class Form;
 }
@@ -42,5 +43,7 @@ public:
 private:
     Ui::Form *ui;
 };
+
+} //namespace DltDbus
 
 #endif // FORM_H

--- a/plugin/dltdbusplugin/form.ui
+++ b/plugin/dltdbusplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>DltDbus::Form</class>
+ <widget class="QWidget" name="DltDbus::Form">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/plugin/dltsystemviewerplugin/dltsystemviewerplugin.cpp
+++ b/plugin/dltsystemviewerplugin/dltsystemviewerplugin.cpp
@@ -82,7 +82,7 @@ QStringList DltSystemViewerPlugin::infoConfig()
 
 QWidget* DltSystemViewerPlugin::initViewer()
 {
-    form = new Form();
+    form = new DltSystemViewer::Form();
     return form;
 }
 

--- a/plugin/dltsystemviewerplugin/dltsystemviewerplugin.h
+++ b/plugin/dltsystemviewerplugin/dltsystemviewerplugin.h
@@ -63,7 +63,7 @@ public:
     void selectedIdxMsgDecoded(int index, QDltMsg &msg);
 
     /* internal variables */
-    Form *form;
+    DltSystemViewer::Form *form;
     int counterMessages;
     int counterNonVerboseMessages;
     int counterVerboseMessages;

--- a/plugin/dltsystemviewerplugin/form.cpp
+++ b/plugin/dltsystemviewerplugin/form.cpp
@@ -21,6 +21,8 @@
 #include "ui_form.h"
 #include "dltsystemviewerplugin.h"
 
+using namespace DltSystemViewer;
+
 ProcessItem::ProcessItem(QTreeWidgetItem *parent)
     : QTreeWidgetItem(parent)
 {

--- a/plugin/dltsystemviewerplugin/form.h
+++ b/plugin/dltsystemviewerplugin/form.h
@@ -24,6 +24,7 @@
 #include <QTreeWidgetItem>
 #include "plugininterface.h"
 
+namespace DltSystemViewer {
 namespace Ui {
     class Form;
 }
@@ -61,5 +62,7 @@ private:
     Ui::Form *ui;
 
 };
+
+} //namespace DltSystemViewer
 
 #endif // FORM_H

--- a/plugin/dltsystemviewerplugin/form.ui
+++ b/plugin/dltsystemviewerplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>DltSystemViewer::Form</class>
+ <widget class="QWidget" name="DltSystemViewer::Form">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/plugin/dltviewerplugin/dltviewerplugin.cpp
+++ b/plugin/dltviewerplugin/dltviewerplugin.cpp
@@ -63,7 +63,7 @@ QStringList DltViewerPlugin::infoConfig() {
 }
 
 QWidget* DltViewerPlugin::initViewer() {
-    form = new Form();
+    form = new DltViewer::Form();
     return form;
 }
 

--- a/plugin/dltviewerplugin/dltviewerplugin.h
+++ b/plugin/dltviewerplugin/dltviewerplugin.h
@@ -63,7 +63,7 @@ public:
     void selectedIdxMsgDecoded(int index, QDltMsg &msg);
 
     /* internal variables */
-    Form *form;
+    DltViewer::Form *form;
 
 private:
 

--- a/plugin/dltviewerplugin/form.cpp
+++ b/plugin/dltviewerplugin/form.cpp
@@ -20,6 +20,8 @@
 #include "form.h"
 #include "ui_form.h"
 
+using namespace DltViewer;
+
 Form::Form(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Form)

--- a/plugin/dltviewerplugin/form.h
+++ b/plugin/dltviewerplugin/form.h
@@ -22,9 +22,10 @@
 
 #include <QWidget>
 
-namespace Ui {
-    class Form;
-}
+namespace DltViewer {
+    namespace Ui {
+        class Form;
+    }
 
 class Form : public QWidget
 {
@@ -44,5 +45,7 @@ public:
 private:
     Ui::Form *ui;
 };
+
+} //namespace DltViewer
 
 #endif // FORM_H

--- a/plugin/dltviewerplugin/form.ui
+++ b/plugin/dltviewerplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>DltViewer::Form</class>
+ <widget class="QWidget" name="DltViewer::Form">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/plugin/dummycontrolplugin/dummycontrolplugin.cpp
+++ b/plugin/dummycontrolplugin/dummycontrolplugin.cpp
@@ -77,7 +77,7 @@ QStringList DummyControlPlugin::infoConfig()
 
 QWidget* DummyControlPlugin::initViewer()
 {
-    form = new Form(this);
+    form = new DummyControl::Form(this);
     return form;
 }
 

--- a/plugin/dummycontrolplugin/dummycontrolplugin.h
+++ b/plugin/dummycontrolplugin/dummycontrolplugin.h
@@ -71,7 +71,7 @@ public:
     bool autoscrollStateChanged(bool enabled);
 
     /* internal variables */
-    Form *form;
+    DummyControl::Form *form;
     int counterMessages;
     int counterNonVerboseMessages;
     int counterVerboseMessages;

--- a/plugin/dummycontrolplugin/form.cpp
+++ b/plugin/dummycontrolplugin/form.cpp
@@ -23,6 +23,8 @@
 
 #include <qfiledialog.h>
 
+using namespace DummyControl;
+
 Form::Form(DummyControlPlugin *_plugin,QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Form)

--- a/plugin/dummycontrolplugin/form.h
+++ b/plugin/dummycontrolplugin/form.h
@@ -24,9 +24,10 @@
 
 class DummyControlPlugin;
 
-namespace Ui {
-    class Form;
-}
+namespace DummyControl {
+    namespace Ui {
+        class Form;
+    }
 
 class Form : public QWidget
 {
@@ -57,4 +58,5 @@ private slots:
     void on_pushButtonReopenFile_clicked();
 };
 
+} // namespace DummyControl
 #endif // FORM_H

--- a/plugin/dummycontrolplugin/form.ui
+++ b/plugin/dummycontrolplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>DummyControl::Form</class>
+ <widget class="QWidget" name="DummyControl::Form">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/plugin/dummyviewerplugin/dummyviewerplugin.cpp
+++ b/plugin/dummyviewerplugin/dummyviewerplugin.cpp
@@ -75,7 +75,7 @@ QStringList DummyViewerPlugin::infoConfig()
 
 QWidget* DummyViewerPlugin::initViewer()
 {
-    form = new Form();
+    form = new DummyViewer::Form();
     return form;
 }
 

--- a/plugin/dummyviewerplugin/dummyviewerplugin.h
+++ b/plugin/dummyviewerplugin/dummyviewerplugin.h
@@ -64,7 +64,7 @@ public:
 
 
     /* internal variables */
-    Form *form;
+    DummyViewer::Form *form;
     int counterMessages;
     int counterNonVerboseMessages;
     int counterVerboseMessages;

--- a/plugin/dummyviewerplugin/form.cpp
+++ b/plugin/dummyviewerplugin/form.cpp
@@ -21,6 +21,8 @@
 #include "ui_form.h"
 #include "dummyviewerplugin.h"
 
+using namespace DummyViewer;
+
 Form::Form(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Form)

--- a/plugin/dummyviewerplugin/form.h
+++ b/plugin/dummyviewerplugin/form.h
@@ -22,9 +22,10 @@
 
 #include <QWidget>
 
-namespace Ui {
-    class Form;
-}
+namespace DummyViewer {
+    namespace Ui {
+        class Form;
+    }
 
 class Form : public QWidget
 {
@@ -41,7 +42,8 @@ public:
 
 private:
     Ui::Form *ui;
-
 };
+
+} //namespace DummyViewer
 
 #endif // FORM_H

--- a/plugin/dummyviewerplugin/form.ui
+++ b/plugin/dummyviewerplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>DummyViewer::Form</class>
+ <widget class="QWidget" name="DummyViewer::Form">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/plugin/filetransferplugin/filetransferplugin.cpp
+++ b/plugin/filetransferplugin/filetransferplugin.cpp
@@ -154,7 +154,7 @@ QStringList FiletransferPlugin::infoConfig()
 
 QWidget* FiletransferPlugin::initViewer()
 {
-    form = new Form();
+    form = new FileTransferPlugin::Form();
     return form;
 }
 

--- a/plugin/filetransferplugin/filetransferplugin.h
+++ b/plugin/filetransferplugin/filetransferplugin.h
@@ -83,7 +83,7 @@ public:
 
 private:
     QString plugin_name_displayed = QString("Filetransfer Plugin");
-    Form *form;
+    FileTransferPlugin::Form *form;
     QDltFile *dltFile;
     QDltControl *dltControl;
     QString errorText;

--- a/plugin/filetransferplugin/form.cpp
+++ b/plugin/filetransferplugin/form.cpp
@@ -33,6 +33,8 @@
 #include "textviewdialog.h"
 #include <QtDebug>
 
+using namespace FileTransferPlugin;
+
 Form::Form(QWidget *parent) :
         QWidget(parent),
         ui(new Ui::Form)

--- a/plugin/filetransferplugin/form.h
+++ b/plugin/filetransferplugin/form.h
@@ -23,9 +23,12 @@
 #include <QWidget>
 #include <QTreeWidget>
 #include "file.h"
-namespace Ui {
-    class Form;
-}
+
+namespace FileTransferPlugin {
+    namespace Ui {
+        class Form;
+    }
+
 
 class Form : public QWidget
 {
@@ -57,5 +60,7 @@ private slots:
     void on_saveRightButton_clicked();
 
 };
+
+}  //namespace FileTransferPlugin
 
 #endif // FORM_H

--- a/plugin/filetransferplugin/form.ui
+++ b/plugin/filetransferplugin/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>FileTransferPlugin::Form</class>
+ <widget class="QWidget" name="FileTransferPlugin::Form">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
On Linux buttons in file transfer plugin did not work. This was caused by duplicate symbols in plugins. 
Form classes were put in namespaces to avoid this situation. 

First commit changes build system to make plugins work out of the box in build directory. All plugins will now be built in a plugins directory. 