### PR TITLE
Improved the performance of the copy selection to clipboard

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1174,7 +1174,7 @@ void MainWindow::exportSelection(bool ascii = true,bool file = false)
 
 void MainWindow::exportSelection_searchTable()
 {
-    QModelIndexList list = ui->tableView_SearchIndex->selectionModel()->selection().indexes();
+    const QModelIndexList list = ui->tableView_SearchIndex->selectionModel()->selectedRows();
 
     // Clear the selection from main table.
     ui->tableView->selectionModel()->clear();


### PR DESCRIPTION
Application performance is too slow when copying a large number of lines from the search results. As we can select only rows selection.indexes() was replaced with selectedRows()