### PR TITLE
Fixing unstable behaviour in MainWindow::nearest_line

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,6 +39,7 @@
 #include <QSerialPort>
 #include <QSerialPortInfo>
 #include <QNetworkProxyFactory>
+#include <QtAlgorithms>
 
 /**
  * From QDlt.
@@ -6228,29 +6229,29 @@ int MainWindow::nearest_line(int line){
          * matching index. If it cannot be found, just settle
          * for the last one that we saw before going over */
         int lastFound = 0;
-        for(int i=0;i<qfile.sizeFilter();i++)
+
+        QVector<qint64> filterIndices = qfile.getIndexFilter();
+
+        if(!filterIndices.isEmpty())
         {
-            if(qfile.getMsgFilterPos(i) == line)
+            lastFound = filterIndices.indexOf(line);
+            if(lastFound < 0)
             {
-                // The correct line is visible.
-                // We can terminate the search
-                lastFound = i;
-                break;
+                QVector<qint64> sortedIndices = filterIndices;
+                qSort(sortedIndices);
+
+                int lastIndex = sortedIndices[0];
+
+                for(auto index: sortedIndices)
+                {
+                    if(index > line)
+                    {
+                        break;
+                    }
+                    lastIndex = index;
+                }
+                lastFound = filterIndices.indexOf(lastIndex);
             }
-            else if(qfile.getMsgFilterPos(i) < line)
-            {
-                // Not found found yet, but line is below current searched line.
-                // Update last found
-                lastFound = i;
-            }
-            else /* qfile.getMsgFilterPos(i) > line */
-            {
-                // Calculate, if we are nearer to the line from last found.
-                // If yes, use current line in search
-                if((qfile.getMsgFilterPos(i)-line)<(line-qfile.getMsgFilterPos(lastFound)))
-                    lastFound = i;
-                break;
-           }
         }
         row = lastFound;
     }


### PR DESCRIPTION
The implementation of MainWindow::nearest_line should search for the
the line of a given index value.

If the index is present in the (filtered)message list the according
line is returned. If it is not present the next present index smaller
than the searched one is used.

The method has been working instable.
The reason for this is the qfile.getIndexFilter() is expected to
return a sorted list. This is not the case.
If the returned list is not sorted, wrong results are returned.

The new version sorts the list and searches in this sorted list.

