### PR TITLE
Add "Resize columns to fit" and "Copy Selection Payload to Clipboard" context menu items to main and search tables

### DIFF
--- a/src/dltexporter.cpp
+++ b/src/dltexporter.cpp
@@ -158,7 +158,8 @@ bool DltExporter::finish()
         /* close output file */
         to->close();
     }
-    else if (exportFormat == DltExporter::FormatClipboard)
+    else if (exportFormat == DltExporter::FormatClipboard ||
+             exportFormat == DltExporter::FormatClipboardPayloadOnly)
     {
         /* export to clipboard */
         QClipboard *clipboard = QApplication::clipboard();
@@ -203,21 +204,27 @@ bool DltExporter::exportMsg(int num, QDltMsg &msg, QByteArray &buf)
     {
         to->write(buf);
     }
-    else if(exportFormat == DltExporter::FormatAscii || exportFormat == DltExporter::FormatUTF8 || exportFormat == DltExporter::FormatClipboard)
+    else if(exportFormat == DltExporter::FormatAscii ||
+            exportFormat == DltExporter::FormatUTF8  ||
+            exportFormat == DltExporter::FormatClipboard ||
+            exportFormat == DltExporter::FormatClipboardPayloadOnly)
     {
         QString text;
 
         /* get message ASCII text */
-        if(exportSelection == DltExporter::SelectionAll)
-            text += QString("%1 ").arg(num);
-        else if(exportSelection == DltExporter::SelectionFiltered)
-            text += QString("%1 ").arg(from->getMsgFilterPos(num));
-        else if(exportSelection == DltExporter::SelectionSelected)
-            text += QString("%1 ").arg(from->getMsgFilterPos(selectedRows[num]));
-        else
-            return false;
-        text += msg.toStringHeader();
-        text += " ";
+        if(exportFormat != DltExporter::FormatClipboardPayloadOnly)
+        {
+            if(exportSelection == DltExporter::SelectionAll)
+                text += QString("%1 ").arg(num);
+            else if(exportSelection == DltExporter::SelectionFiltered)
+                text += QString("%1 ").arg(from->getMsgFilterPos(num));
+            else if(exportSelection == DltExporter::SelectionSelected)
+                text += QString("%1 ").arg(from->getMsgFilterPos(selectedRows[num]));
+            else
+                return false;
+            text += msg.toStringHeader();
+            text += " ";
+        }
         text += msg.toStringPayload().simplified();
         text += "\n";
         try
@@ -227,7 +234,8 @@ bool DltExporter::exportMsg(int num, QDltMsg &msg, QByteArray &buf)
                 to->write(text.toLatin1().constData());
             else if (exportFormat == DltExporter::FormatUTF8)
                 to->write(text.toUtf8().constData());
-            else if(exportFormat == DltExporter::FormatClipboard)
+            else if(exportFormat == DltExporter::FormatClipboard ||
+                    exportFormat == DltExporter::FormatClipboardPayloadOnly)
                 clipboardString += text;
          }
         catch (...)

--- a/src/dltexporter.h
+++ b/src/dltexporter.h
@@ -14,7 +14,7 @@ class DltExporter : public QObject
 
 public:
 
-    typedef enum { FormatDlt,FormatAscii,FormatCsv,FormatClipboard,FormatDltDecoded,FormatUTF8} DltExportFormat;
+    typedef enum { FormatDlt,FormatAscii,FormatCsv,FormatClipboard,FormatClipboardPayloadOnly,FormatDltDecoded,FormatUTF8} DltExportFormat;
 
     typedef enum { SelectionAll,SelectionFiltered,SelectionSelected } DltExportSelection;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5958,6 +5958,12 @@ void MainWindow::on_tableView_customContextMenuRequested(QPoint pos)
     connect(action, SIGNAL(triggered()), this, SLOT(on_action_menuFilter_Load_triggered()));
     menu.addAction(action);
 
+    menu.addSeparator();
+
+    action = new QAction("Resize columns to fit", this);
+    connect(action, SIGNAL(triggered()), ui->tableView, SLOT(resizeColumnsToContents()));
+    menu.addAction(action);
+
     /* show popup menu */
     menu.exec(globalPos);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1202,18 +1202,20 @@ void MainWindow::on_action_menuFile_Append_DLT_File_triggered()
 
 }
 
-void MainWindow::exportSelection(bool ascii = true,bool file = false)
+void MainWindow::exportSelection(bool ascii = true,bool file = false,bool payload_only = false)
 {
     Q_UNUSED(ascii);
     Q_UNUSED(file);
 
     QModelIndexList list = ui->tableView->selectionModel()->selection().indexes();
 
+    DltExporter::DltExportFormat exportFormat = (payload_only ? DltExporter::FormatClipboardPayloadOnly : DltExporter::FormatClipboard);
+
     DltExporter exporter;
-    exporter.exportMessages(&qfile,0,&pluginManager,DltExporter::FormatClipboard,DltExporter::SelectionSelected,&list);
+    exporter.exportMessages(&qfile,0,&pluginManager,exportFormat,DltExporter::SelectionSelected,&list);
 }
 
-void MainWindow::exportSelection_searchTable()
+void MainWindow::exportSelection_searchTable(bool payload_only = false)
 {
     const QModelIndexList list = ui->tableView_SearchIndex->selectionModel()->selectedRows();
 
@@ -1243,8 +1245,10 @@ void MainWindow::exportSelection_searchTable()
 
     QModelIndexList finallist = ui->tableView->selectionModel()->selection().indexes();
 
+    DltExporter::DltExportFormat exportFormat = (payload_only ? DltExporter::FormatClipboardPayloadOnly : DltExporter::FormatClipboard);
+
     DltExporter exporter;
-    exporter.exportMessages(&qfile,0,&pluginManager,DltExporter::FormatClipboard,DltExporter::SelectionSelected,&finallist);
+    exporter.exportMessages(&qfile,0,&pluginManager,exportFormat,DltExporter::SelectionSelected,&finallist);
 }
 
 void MainWindow::on_actionExport_triggered()
@@ -5937,6 +5941,10 @@ void MainWindow::on_tableView_customContextMenuRequested(QPoint pos)
     connect(action, SIGNAL(triggered()), this, SLOT(on_action_menuConfig_Copy_to_clipboard_triggered()));
     menu.addAction(action);
 
+    action = new QAction("C&opy Selection Payload to Clipboard", this);
+    connect(action, SIGNAL(triggered()), this, SLOT(on_action_menuConfig_Copy_Payload_to_clipboard_triggered()));
+    menu.addAction(action);
+
     menu.addSeparator();
 
     action = new QAction("&Export...", this);
@@ -5979,6 +5987,10 @@ void MainWindow::on_tableView_SearchIndex_customContextMenuRequested(QPoint pos)
     connect(action, &QAction::triggered, this, &MainWindow::onActionMenuConfigSearchTableCopyToClipboardTriggered);
     menu.addAction(action);
 
+    action = new QAction("C&opy Selection Payload to Clipboard", this);
+    connect(action, &QAction::triggered, this, &MainWindow::onActionMenuConfigSearchTableCopyPayloadToClipboardTriggered);
+    menu.addAction(action);
+
     menu.addSeparator();
 
     action = new QAction("Resize columns to fit", this);
@@ -5994,6 +6006,11 @@ void MainWindow::on_tableView_SearchIndex_customContextMenuRequested(QPoint pos)
 void MainWindow::onActionMenuConfigSearchTableCopyToClipboardTriggered()
 {
     exportSelection_searchTable();
+}
+
+void MainWindow::onActionMenuConfigSearchTableCopyPayloadToClipboardTriggered()
+{
+    exportSelection_searchTable(true);
 }
 
 void MainWindow::keyPressEvent ( QKeyEvent * event )
@@ -6211,6 +6228,11 @@ void MainWindow::on_action_menuConfig_Expand_All_ECUs_triggered()
 void MainWindow::on_action_menuConfig_Copy_to_clipboard_triggered()
 {
     exportSelection(true,false);
+}
+
+void MainWindow::on_action_menuConfig_Copy_Payload_to_clipboard_triggered()
+{
+    exportSelection(true,false,true);
 }
 
 void MainWindow::on_action_menuFilter_Append_Filters_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5981,6 +5981,12 @@ void MainWindow::on_tableView_SearchIndex_customContextMenuRequested(QPoint pos)
 
     menu.addSeparator();
 
+    action = new QAction("Resize columns to fit", this);
+    connect(action, SIGNAL(triggered()), ui->tableView_SearchIndex, SLOT(resizeColumnsToContents()));
+    menu.addAction(action);
+
+    menu.addSeparator();
+
     /* show popup menu */
     menu.exec(globalPos);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -243,8 +243,8 @@ private:
 
     void reloadLogFileDefaultFilter();
 
-    void exportSelection(bool ascii,bool file);
-    void exportSelection_searchTable();
+    void exportSelection(bool ascii,bool file,bool payload_only);
+    void exportSelection_searchTable(bool payload_only);
 
     void ControlServiceRequest(EcuItem* ecuitem, int service_id );
     void SendInjection(EcuItem* ecuitem);
@@ -435,7 +435,9 @@ private slots:
     void on_action_menuConfig_Connect_triggered();
     void on_action_menuConfig_Delete_All_Contexts_triggered();
     void on_action_menuConfig_Copy_to_clipboard_triggered();
+    void on_action_menuConfig_Copy_Payload_to_clipboard_triggered();
     void onActionMenuConfigSearchTableCopyToClipboardTriggered();
+    void onActionMenuConfigSearchTableCopyPayloadToClipboardTriggered();
 
     // DLT methods
     void on_action_menuDLT_Send_Injection_triggered();


### PR DESCRIPTION
The attached patch adds a "Resize columns to fit" item to the main table's context menu.
