### PR TITLE
[cmake]: Support standard unix locations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,25 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BIN_DIR})
 
 add_definitions(-DQT5)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)   # set location for all executables in the build folder
+
+option(USE_STANDARD_INSTALLATION_LOCATION "Use standard GNU installation locations" OFF)
+
+if (USE_STANDARD_INSTALLATION_LOCATION)
+    include(GNUInstallDirs)    # for standard installation locations
+    set(PLUGIN_INSTALLATION_PATH ${CMAKE_INSTALL_FULL_LIBDIR}/dlt-viewer/plugins)
+    set(RESOURCE_INSTALLATION_PATH ${CMAKE_INSTALL_FULL_DATADIR}/dlt-viewer)
+    set(EXECUTABLE_INSTALLATION_PATH ${CMAKE_INSTALL_FULL_BINDIR})
+    set(LIBRARY_INSTALLATION_PATH ${CMAKE_INSTALL_FULL_LIBDIR})
+else()
+    set(PLUGIN_INSTALLATION_PATH deploy/plugins)
+    set(RESOURCE_INSTALLATION_PATH deploy)
+    set(EXECUTABLE_INSTALLATION_PATH deploy)
+    set(LIBRARY_INSTALLATION_PATH deploy)
+endif()
+
+add_definitions(-DPLUGIN_INSTALLATION_PATH="${PLUGIN_INSTALLATION_PATH}")
+
 add_subdirectory(parser)
 add_subdirectory(qdlt)
 add_subdirectory(src)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -28,4 +28,4 @@ add_executable(dlt_parser main.cpp
 
 target_link_libraries(dlt_parser Qt5::Widgets )
 
-install(TARGETS dlt_parser DESTINATION deploy)
+install(TARGETS dlt_parser DESTINATION ${EXECUTABLE_INSTALLATION_PATH})

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -24,6 +24,21 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PLUGIN_DIR})
 
 
+function(add_plugin NAME)
+
+    target_link_libraries(${NAME} qdlt Qt5::Widgets)
+    install(TARGETS ${NAME} DESTINATION ${PLUGIN_INSTALLATION_PATH})
+
+    # set the location of the plugins in such a way that they can be located by the dlt-viewer executable when running in
+    # directly from the build folder (without "make install")
+    set_target_properties(${NAME} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    )
+
+endfunction()
+
+
 add_subdirectory(dltviewerplugin)
 add_subdirectory(nonverboseplugin)
 add_subdirectory(filetransferplugin)

--- a/plugin/dltdbusplugin/CMakeLists.txt
+++ b/plugin/dltdbusplugin/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(dltdbusplugin MODULE dltdbusplugin.cpp
 
 target_link_libraries(dltdbusplugin qdlt Qt5::Widgets )
 
-install(TARGETS dltdbusplugin DESTINATION deploy/plugins)
+add_plugin(dltdbusplugin)

--- a/plugin/dltlogstorageplugin/CMakeLists.txt
+++ b/plugin/dltlogstorageplugin/CMakeLists.txt
@@ -24,4 +24,5 @@ add_library(dltlogstorageplugin MODULE dltlogstorageconfigcreatorplugin.cpp
     ${UI_HEADERS})
 
 target_link_libraries(dltlogstorageplugin qdlt Qt5::Widgets )
-install(TARGETS dltlogstorageplugin DESTINATION deploy/plugins)
+
+add_plugin(dltlogstorageplugin)

--- a/plugin/dltsystemviewerplugin/CMakeLists.txt
+++ b/plugin/dltsystemviewerplugin/CMakeLists.txt
@@ -23,4 +23,5 @@ add_library(dltsystemviewerplugin MODULE dltsystemviewerplugin.cpp
                           	${UI_HEADERS})
 
 target_link_libraries(dltsystemviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dltsystemviewerplugin DESTINATION deploy/plugins)
+
+add_plugin(dltsystemviewerplugin)

--- a/plugin/dltviewerplugin/CMakeLists.txt
+++ b/plugin/dltviewerplugin/CMakeLists.txt
@@ -26,4 +26,5 @@ add_library(dltviewerplugin MODULE dltviewerplugin.cpp
 	                        ${UI_HEADERS})
 
 target_link_libraries(dltviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dltviewerplugin DESTINATION deploy/plugins)
+
+add_plugin(dltviewerplugin)

--- a/plugin/dummycommandplugin/CMakeLists.txt
+++ b/plugin/dummycommandplugin/CMakeLists.txt
@@ -26,4 +26,4 @@ add_library(dummycommandplugin MODULE dummycommandplugin.cpp
 	                        ${UI_HEADERS})
 
 target_link_libraries(dummycommandplugin qdlt Qt5::Widgets )
-install(TARGETS dummycommandplugin DESTINATION deploy/plugins)
+add_plugin(dummycommandplugin)

--- a/plugin/dummycontrolplugin/CMakeLists.txt
+++ b/plugin/dummycontrolplugin/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(dummycontrolplugin MODULE dummycontrolplugin.cpp
    ${UI_HEADERS})
 
 target_link_libraries(dummycontrolplugin qdlt Qt5::Widgets )
-install(TARGETS dummycontrolplugin DESTINATION deploy/plugins)
+add_plugin(dummycontrolplugin)

--- a/plugin/dummydecoderplugin/CMakeLists.txt
+++ b/plugin/dummydecoderplugin/CMakeLists.txt
@@ -22,4 +22,4 @@ add_library(dummydecoderplugin MODULE dummydecoderplugin.cpp
                         ${UI_HEADERS})
 
 target_link_libraries(dummydecoderplugin qdlt Qt5::Widgets )
-install(TARGETS dummydecoderplugin DESTINATION deploy/plugins)
+add_plugin(dummydecoderplugin)

--- a/plugin/dummyviewerplugin/CMakeLists.txt
+++ b/plugin/dummyviewerplugin/CMakeLists.txt
@@ -23,4 +23,4 @@ add_library(dummyviewerplugin MODULE dummyviewerplugin.cpp
                           	${UI_HEADERS})
 
 target_link_libraries(dummyviewerplugin qdlt Qt5::Widgets )
-install(TARGETS dummyviewerplugin DESTINATION deploy/plugins)
+add_plugin(dummyviewerplugin)

--- a/plugin/filetransferplugin/CMakeLists.txt
+++ b/plugin/filetransferplugin/CMakeLists.txt
@@ -32,4 +32,4 @@ add_library(filetransferplugin 	MODULE filetransferplugin.cpp
 
 target_link_libraries(filetransferplugin qdlt Qt5::Widgets Qt5::PrintSupport )
 
-install(TARGETS filetransferplugin DESTINATION deploy/plugins)
+add_plugin(filetransferplugin)

--- a/plugin/nonverboseplugin/CMakeLists.txt
+++ b/plugin/nonverboseplugin/CMakeLists.txt
@@ -23,4 +23,4 @@ add_library(nonverboseplugin MODULE nonverboseplugin.cpp
 
 target_link_libraries(nonverboseplugin qdlt Qt5::Widgets )
 
-install(TARGETS nonverboseplugin DESTINATION deploy/plugins)
+add_plugin(nonverboseplugin)

--- a/qdlt/CMakeLists.txt
+++ b/qdlt/CMakeLists.txt
@@ -51,4 +51,4 @@ endif()
 
 target_link_libraries(qdlt ${QDLT_LINK_LIBS})
 
-install(TARGETS qdlt DESTINATION deploy)
+install(TARGETS qdlt DESTINATION ${LIBRARY_INSTALLATION_PATH})

--- a/qdlt/qdlt.pro
+++ b/qdlt/qdlt.pro
@@ -15,6 +15,7 @@ DEFINES += QDLT_LIBRARY
     QMAKE_CXXFLAGS += -std=gnu++0x
     QMAKE_CXXFLAGS += -Wall
     QMAKE_CXXFLAGS += -Wextra
+    QMAKE_CXXFLAGS += -DPLUGIN_INSTALLATION_PATH=\\\"$$PREFIX/usr/share/dlt-viewer/plugins\\\"
     #QMAKE_CXXFLAGS += -pedantic
 }
 

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -32,9 +32,19 @@ QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
 {
     QDir pluginsDir;
     QStringList errorStrings;
+
+    QString defaultPluginPath = PLUGIN_INSTALLATION_PATH;
+
     /* The viewer looks in the relativ to the executable in the ./plugins directory */
     pluginsDir.setPath(QCoreApplication::applicationDirPath());
     if(pluginsDir.cd("plugins"))
+    {
+        errorStrings << loadPluginsPath(pluginsDir);
+    }
+
+    /* Check system plugins path */
+    pluginsDir.setPath(defaultPluginPath);
+    if(pluginsDir.exists())
     {
         errorStrings << loadPluginsPath(pluginsDir);
     }
@@ -47,13 +57,6 @@ QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
         {
             errorStrings << loadPluginsPath(pluginsDir);
         }
-    }
-
-    /* Load plugins from system directory in linux */
-    pluginsDir.setPath("/usr/share/dlt-viewer/plugins");
-    if(pluginsDir.exists() && pluginsDir.isReadable())
-    {
-        errorStrings << loadPluginsPath(pluginsDir);
     }
 
     return errorStrings;


### PR DESCRIPTION
Enable use of standard GNU installation locations
Add an option to get the software installed using the standard
GNU installation location ("executables in "bin" folder,
libraries in "lib", etc...).

Based on d66567a810f01940a6657e2b497b7718824ae150, but fixed
handling of the plugins path.