### PR TITLE
fixed DltTableView display bug

### DIFF
--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -388,7 +388,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
             case FieldNames::ArgCount:
                 return QVariant(Qt::AlignRight  | Qt::AlignVCenter);
             case FieldNames::Payload:
-                return QVariant(Qt::AlignLeft   | Qt::AlignVCenter);
+                return QVariant(Qt::AlignLeft);
         }
     }
 


### PR DESCRIPTION
The payload (and actually all cells) started wrapping words after I upgraded my system to Fedora 30.
Since I don't have much Qt experience, I did a quick fix to read the payload better.
This fix just removed the vertical center alignment of payload cells in the TableModel.

Example: the payload text is wrapped to 3 lines. I can only view the second line because the cells height wasn't big enough to fit all 3 lines.

This is just a quick and dirty fix for my situation. I hope it's still helpful to find the root cause.
Perhaps this is a system specific issue. If there is any setting (or Qt version) I need to use, please tell me :)

For the long term it would be better to disable the word wrap completely.