### PR TITLE
README: Fix links to mailing list and wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ https://github.com/GENIVI/dlt-viewer
 
 ## Homepage
 
-https://at.projects.genivi.org/wiki/display/PROJ/Diagnostic+Log+and+Trace
+[Diagnostic Log and Trace](https://at.projects.genivi.org/wiki/display/PROJ/Diagnostic+Log+and+Trace) on GENIVI Projects Wiki
 
 ## Mailinglist
 
-https://lists.genivi.org/mailman/listinfo/genivi-diagnostic-log-and-trace
+[genivi-diagnostic-log-and-trace](https://lists.genivi.org/mailman/listinfo/genivi-diagnostic-log-and-trace_lists.genivi.org)
 
 ## Contact
 


### PR DESCRIPTION
The mailing list URL have unfortunately changed slightly.  The wiki page
URL is unchanged, but the link is now more nicely formatted.
