### PR TITLE
Extension of QDltPluginControlInterface with new notification events

### DIFF
--- a/plugin/dltdbusplugin/dltdbusplugin.cpp
+++ b/plugin/dltdbusplugin/dltdbusplugin.cpp
@@ -812,7 +812,18 @@ bool DltDBusPlugin::autoscrollStateChanged(bool enabled)
     return true;
 }
 
+void DltDBusPlugin::initMessageDecoder(QDltMessageDecoder* pMessageDecoder)
+{
+    Q_UNUSED(pMessageDecoder);
+}
 
+void DltDBusPlugin::initMainTableView(QTableView* pTableView)
+{
+    Q_UNUSED(pTableView);
+}
+
+void DltDBusPlugin::configurationChanged()
+{}
 
 #ifndef QT5
 Q_EXPORT_PLUGIN2(dltdbusplugin, DltDBusPlugin);

--- a/plugin/dltdbusplugin/dltdbusplugin.h
+++ b/plugin/dltdbusplugin/dltdbusplugin.h
@@ -115,7 +115,9 @@ public:
     bool controlMsg(int index, QDltMsg &msg);
     bool stateChanged(int index, QDltConnection::QDltConnectionState connectionState, QString hostname);
     bool autoscrollStateChanged(bool enabled);
-
+    void initMessageDecoder(QDltMessageDecoder* pMessageDecoder);
+    void initMainTableView(QTableView* pTableView);
+    void configurationChanged();
 
     /* QDltPluginDecoderInterface */
     bool isMsg(QDltMsg &msg, int triggeredByUser);

--- a/plugin/dummycontrolplugin/dummycontrolplugin.cpp
+++ b/plugin/dummycontrolplugin/dummycontrolplugin.cpp
@@ -120,6 +120,19 @@ bool DummyControlPlugin::autoscrollStateChanged(bool enabled)
     return true;
 }
 
+void DummyControlPlugin::initMessageDecoder(QDltMessageDecoder* pMessageDecoder)
+{
+    Q_UNUSED(pMessageDecoder);
+}
+
+void DummyControlPlugin::initMainTableView(QTableView* pTableView)
+{
+    Q_UNUSED(pTableView);
+}
+
+void DummyControlPlugin::configurationChanged()
+{}
+
 void DummyControlPlugin::selectedIdxMsg(int , QDltMsg &) {
 
 }

--- a/plugin/dummycontrolplugin/dummycontrolplugin.h
+++ b/plugin/dummycontrolplugin/dummycontrolplugin.h
@@ -69,6 +69,9 @@ public:
     bool controlMsg(int index, QDltMsg &msg);
     bool stateChanged(int index, QDltConnection::QDltConnectionState connectionState,QString hostname);
     bool autoscrollStateChanged(bool enabled);
+    void initMessageDecoder(QDltMessageDecoder* pMessageDecoder);
+    void initMainTableView(QTableView* pTableView);
+    void configurationChanged();
 
     /* internal variables */
     DummyControl::Form *form;

--- a/plugin/filetransferplugin/filetransferplugin.cpp
+++ b/plugin/filetransferplugin/filetransferplugin.cpp
@@ -453,6 +453,18 @@ bool FiletransferPlugin::autoscrollStateChanged(bool enabled)
     return true;
 }
 
+void FiletransferPlugin::initMessageDecoder(QDltMessageDecoder* pMessageDecoder)
+{
+    Q_UNUSED(pMessageDecoder);
+}
+
+void FiletransferPlugin::initMainTableView(QTableView* pTableView)
+{
+    Q_UNUSED(pTableView);
+}
+
+void FiletransferPlugin::configurationChanged()
+{}
 
 
 #ifndef QT5

--- a/plugin/filetransferplugin/filetransferplugin.h
+++ b/plugin/filetransferplugin/filetransferplugin.h
@@ -79,6 +79,9 @@ public:
     bool controlMsg(int index, QDltMsg &msg);
     bool stateChanged(int index, QDltConnection::QDltConnectionState connectionState, QString hostname);
     bool autoscrollStateChanged(bool enabled);
+    void initMessageDecoder(QDltMessageDecoder* pMessageDecoder);
+    void initMainTableView(QTableView* pTableView);
+    void configurationChanged();
 
 
 private:

--- a/qdlt/qdlt.h
+++ b/qdlt/qdlt.h
@@ -37,6 +37,7 @@
 #include <qdlttcpconnection.h>
 #include <qdltudpconnection.h>
 #include <qdltserialconnection.h>
+#include <qdltmessagedecoder.h>
 #include <qdltplugin.h>
 #include <qdltpluginmanager.h>
 #include <qdltoptmanager.h>

--- a/qdlt/qdlt.pro
+++ b/qdlt/qdlt.pro
@@ -58,6 +58,7 @@ INCLUDEPATH = . ../src
 SOURCES +=  \
     dlt_common.c \
     qdltipconnection.cpp \
+    qdltmessagedecoder.cpp \
     qdlttcpconnection.cpp \
     qdltudpconnection.cpp \
     qdltserialconnection.cpp \
@@ -82,6 +83,7 @@ HEADERS += qdlt.h \
     dlt_common.h \
     dlt_user.h \
     qdltipconnection.h \
+    qdltmessagedecoder.h \
     qdlttcpconnection.h \
     qdltudpconnection.h \
     qdltserialconnection.h \

--- a/qdlt/qdltmessagedecoder.cpp
+++ b/qdlt/qdltmessagedecoder.cpp
@@ -1,0 +1,32 @@
+/**
+ * @licence app begin@
+ * Copyright (C) 2015-2016  Harman Becker Automotive Systems GmbH
+ *
+ * This file is part of GENIVI Project Dlt Viewer.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \author Olaf Dreyer <olaf.dreyer@harman.com>
+ *
+ * \file qdltmessagedecoder.cpp
+ * For further information see http://www.genivi.org/.
+ * @licence end@
+ */
+
+#include "qdltmessagedecoder.h"
+
+QDltMessageDecoder::QDltMessageDecoder()
+{
+
+}
+
+QDltMessageDecoder::~QDltMessageDecoder()
+{
+
+}

--- a/qdlt/qdltmessagedecoder.h
+++ b/qdlt/qdltmessagedecoder.h
@@ -1,0 +1,45 @@
+/**
+ * @licence app begin@
+ * Copyright (C) 2015-2016  Harman Becker Automotive Systems GmbH
+ *
+ * This file is part of GENIVI Project Dlt Viewer.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \author Olaf Dreyer <olaf.dreyer@harman.com>
+ *
+ * \file qdltmessagedecoder.h
+ * For further information see http://www.genivi.org/.
+ * @licence end@
+ */
+
+#ifndef QDLTMESSAGEDECODER_HPP
+
+#include "export_rules.h"
+
+class QDltMsg;
+
+class QDLT_EXPORT QDltMessageDecoder
+{
+public:
+    QDltMessageDecoder();
+    virtual ~QDltMessageDecoder();
+
+    //! Decode message by decoding through all loaded an activated decoder plugins.
+    /*!
+      \param msg The message to be decoded.
+      \param triggeredByUser Whether decode operation was triggered by the user or not
+    */
+    virtual void decodeMsg(QDltMsg& /*msg*/, int /*triggeredByUser*/){}
+
+private:
+    QDltMessageDecoder(const QDltMessageDecoder&) = delete;
+    QDltMessageDecoder& operator= (const QDltMessageDecoder&) = delete;
+};
+#endif // QDLTMESSAGEDECODER_HPP

--- a/qdlt/qdltplugin.cpp
+++ b/qdlt/qdltplugin.cpp
@@ -2,6 +2,8 @@
 
 #include <QDir>
 #include <QCoreApplication>
+#include <QTableView>
+
 #include <QPluginLoader>
 
 QDltPlugin::QDltPlugin()
@@ -216,6 +218,24 @@ void QDltPlugin::selectedIdxMsgDecoded(int index, QDltMsg &msg)
 {
 if(pluginviewerinterface)
     pluginviewerinterface->selectedIdxMsgDecoded(index,msg);
+}
+
+void QDltPlugin::initMessageDecoder(QDltMessageDecoder* messageDecoder)
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->initMessageDecoder(messageDecoder);
+}
+
+void QDltPlugin::initMainTableView(QTableView* pTableView)
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->initMainTableView(pTableView);
+}
+
+void QDltPlugin::configurationChanged()
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->configurationChanged();
 }
 
 // control plugin interface

--- a/qdlt/qdltplugin.h
+++ b/qdlt/qdltplugin.h
@@ -12,6 +12,7 @@ class QDLTPluginDecoderInterface;
 class QDltPluginViewerInterface;
 class QDltPluginControlInterface;
 class QDltPluginCommandInterface;
+class QTableView;
 
 //! Access class to a DLT Plugin to decode, view and control DLT messages
 /*!
@@ -107,6 +108,9 @@ public:
     void updateFileFinish();
     void selectedIdxMsg(int index, QDltMsg &msg);
     void selectedIdxMsgDecoded(int index, QDltMsg &msg);
+    void initMessageDecoder(QDltMessageDecoder* messageDecoder);
+    void initMainTableView(QTableView* pTableView);
+    void configurationChanged();
 
     // control plugin interfaces
     bool initControl(QDltControl *control);

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -91,6 +91,7 @@ QStringList QDltPluginManager::loadPluginsPath(QDir &dir)
 
                     QDltPlugin* item = new QDltPlugin();
                     item->loadPlugin(plugin);
+                    item->initMessageDecoder(this);
                     plugins.append(item);
 
                     //project.plugin->addTopLevelItem(item);

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -14,7 +14,7 @@
 
 class QDltPlugin;
 
-class QDLT_EXPORT QDltPluginManager
+class QDLT_EXPORT QDltPluginManager : public QDltMessageDecoder
 {
 public:
 
@@ -50,11 +50,13 @@ public:
     */
     void loadConfig(QString pluginName,QString filename);
 
-    //! Decode message by decoding through all loaded an activated decoder plugins
+    //! Implementation of QDltMessageDecoder's pure virtual method.
+    //! Decode message by decoding through all loaded an activated decoder plugins.
     /*!
       \param msg The message to be decoded.
+      \param triggeredByUser Whether decode operation was triggered by the user or not
     */
-    void decodeMsg(QDltMsg &msg,int triggeredByUser);
+    void decodeMsg(QDltMsg &msg,int triggeredByUser) override;
 
     //! Get the list of pointers to all loaded plugins
     QList<QDltPlugin*> getPlugins() { return plugins; }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5582,6 +5582,8 @@ void MainWindow::loadPlugins()
     {
       QDltPlugin* plugin = plugins[idx];
 
+      plugin->initMainTableView( ui->tableView );
+
       PluginItem* item = new PluginItem(0,plugin);
 
       plugin->setMode((QDltPlugin::Mode) QDltSettingsManager::getInstance()->value("plugin/pluginmodefor"+plugin->getName(),QVariant(QDltPlugin::ModeDisable)).toInt());
@@ -6856,6 +6858,11 @@ void MainWindow::on_checkBoxSortByTime_toggled(bool checked)
 
 void MainWindow::syncCheckBoxesAndMenu()
 {
+    auto pluginList = pluginManager.getPlugins();
+
+    for(auto& plugin : pluginList)
+        plugin->configurationChanged();
+
     ui->actionToggle_SortByTimeEnabled->setChecked(ui->checkBoxSortByTime->isChecked());
     if (ui->checkBoxSortByTime->isChecked())
         {


### PR DESCRIPTION
- Add possibility to inject message decoder facade into the
plugin
Motivation: allow plugin to decode messages, which it retrieves
from the QDltFile.
- Add possibility to inject main table view into the
plugin
Motivation: allow plugin to scroll main table view to a certain
row
- Add possibility to notify the plugin about the changed
configuration
Motivation: plugin should be able to reset its analysis
data in case of changed configuration
- Extend comments of QDltPluginViewerInterface::initMsg &
QDltPluginViewerInterface::initMsgDecoded methods in order to
reflect its cross-thread calling nature

All done changes were tested on a
self-made plugin.
Decoding of messages works as expected
Scrolling of
main table works as expected
Reaction on certain configuration-change
use-cases works as expected:
- filtering enabled & disabled
- filter
settings changed
- sort by time enabled & disabled

Signed-off-by: Vladyslav Goncharuk <svlad1990@gmail.com>