### PR TITLE
Update INSTALL.txt 

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -21,7 +21,7 @@ Instructions for installing DLT Viewer (Linux command line)
 * sudo apt install libqt5serialport5-dev
 * mkdir build
 * cd build
-* qmake-qt5 ../BuildDltViewer.pro
+* qmake ../BuildDltViewer.pro
 * make
 * sudo make install
 * sudo ldconfig


### PR DESCRIPTION
Use `qmake` instead of `qmake-qt5` in Linux install instructions. 
Because `qt5-default` doesn't install `qmake-qt5`, but `qmake` .

Test environment: ubuntu 18.04 LTS