### PR TITLE
High DPI Displays Support on macOS

### DIFF
--- a/src/Darwin.cmake
+++ b/src/Darwin.cmake
@@ -23,3 +23,9 @@ get_filename_component(MAC_DEPLOY_TOOL ${MOC_LOCATION}/../macdeployqt ABSOLUTE)
 add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
   COMMAND ${MAC_DEPLOY_TOOL} $<TARGET_FILE_DIR:${TARGET_NAME}>/../.. -always-overwrite
 )
+
+# enable high-DPI displays support
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+  COMMAND plutil -replace NSPrincipalClass -string NSApplication $<TARGET_FILE_DIR:${TARGET_NAME}>/../Info.plist
+  COMMAND plutil -replace NSHighResolutionCapable -bool true $<TARGET_FILE_DIR:${TARGET_NAME}>/../Info.plist
+)


### PR DESCRIPTION
Added `Info.plist` configuration on the post-build stage.

According to [Qt Documentation - High DPI Displays](https://doc.qt.io/qt-5/highdpi.html) the high-DPI support is enabled by settings in `Info.plist` file by adding `NSPrincipalClass - NSApplication` and `NSHighResolutionCapable - true`.

Without the high-DPI configuration the DLT Viewer app looks bad on the Retina and higher displays.

**High DPI Support Disabled**
<img width="1221" alt="DLT_Viewer_Without_High_DPI_Support" src="https://user-images.githubusercontent.com/20271014/77469291-81404f00-6e17-11ea-9f50-bfe3e1f5c4ff.png">

**High DPI Support Enabled**
<img width="1225" alt="DLT_Viewer_With_High_DPI_Support" src="https://user-images.githubusercontent.com/20271014/77469301-86050300-6e17-11ea-9270-1c2d5e74474d.png">

