### PR TITLE
Fix: macOS qmake build

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -20,7 +20,11 @@ QT_VER_MIN = $$member(QT_VERSION, 1)
 
 CONFIG += console
 
-QMAKE_LFLAGS += -Wl,-rpath=.
+macx {
+    QMAKE_LFLAGS += -Wl,-rpath .
+} else {
+    QMAKE_LFLAGS += -Wl,-rpath=.
+}
 
 # Uncomment to add debug symbols to Release build
 #QMAKE_CXXFLAGS_RELEASE += -g


### PR DESCRIPTION
Corrected the `rpath` option for macOS

The macOS uses the Clang compiler. The [`rpath` syntax for Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-rpath) differs from GCC.

- Clang: -rpath <arg>
- GCC: -rpath=dir

The change was introduced due to the build failing with error:
```
ld: unknown option: -rpath=.
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```