### PR TITLE
Feature: Travis CI Support

### DIFF
--- a/.ci/travis/build.sh
+++ b/.ci/travis/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+  readonly Qt5_DIR="/usr/local/opt/qt"
+fi
+
+mkdir build
+cd build
+
+# Building with CMake
+cmake ../
+make
+
+# Cleanup
+rm -rf *
+
+# Building with QMake
+qmake ../BuildDltViewer.pro
+make

--- a/.ci/travis/install.sh
+++ b/.ci/travis/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew link qt --force
+else
+    sudo apt-get update
+    sudo apt-get install -y build-essential qt5-default libqt5serialport5-dev
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: cpp
+
+linux: &linux
+  os: linux
+  services:
+    - docker
+
+macos_high_sierra: &macos_high_sierra
+  os: osx
+  osx_image: xcode10.1
+
+macos_mojave: &macos_mojave
+  os: osx
+  osx_image: xcode11.3.1
+
+jobs:
+  include:
+    - <<: *linux
+      dist: xenial
+    - <<: *linux
+      dist: bionic
+    - <<: *macos_high_sierra
+    - <<: *macos_mojave
+
+install:
+  - chmod +x .ci/travis/install.sh
+  - ./.ci/travis/install.sh
+
+script:
+  - chmod +x .ci/travis/build.sh
+  - ./.ci/travis/build.sh


### PR DESCRIPTION
Added Travis CI support

Build Matrix includes the following systems:

- Ubuntu 16.04 (Xenial)
- Ubuntu 18.04 (Bionic)
- macOS 10.13 (High Sierra)
- macOS 10.14 (Mojave)

During each job, the CMake and QMake builds are performed

**Notes:**
* For setup, the repository should be activated on https://travis-ci.org (Free Travis for Open Source projects)
* Currently, the macOS QMake build is broken, so the Xcode jobs will be marked as failed. The fix: [GENIVI/dlt-viewer/pull/96](https://github.com/GENIVI/dlt-viewer/pull/96)

**Motivation:**
The DLT Viewer repository has the configured CI for the Windows platform but lacks support for Linux and macOS. The further maintaining and development will be easier if all supported platforms will be built during the CI process.