### PR TITLE
Introduction of the QDltFile::getFileMsgNumber method

### DIFF
--- a/qdlt/qdltfile.cpp
+++ b/qdlt/qdltfile.cpp
@@ -423,6 +423,14 @@ QString QDltFile::getFileName(int num)
     return files[num]->infile.fileName();
 }
 
+int QDltFile::getFileMsgNumber(int num) const
+{
+    if(num<0 || num>=files.size())
+        return -1;
+
+    return files[num]->indexAll.size();
+}
+
 void QDltFile::close()
 {
     /* close file */

--- a/qdlt/qdltfile.h
+++ b/qdlt/qdltfile.h
@@ -261,6 +261,12 @@ public:
      **/
     QString getFileName(int num = 0);
 
+    //! Get number of messages of the underlying file object
+    /*!
+     * \return File size or -1 in case of "wrong "out of range" input index
+     **/
+    int getFileMsgNumber(int num = 0) const;
+
     //! Get Index of all DLT messages matching filter
     /*!
      * \return List of file positions


### PR DESCRIPTION
Change description:
- Addition of the QDltFile::getFileMsgNumber method, which allows to get number of messages of the underlying file object

Verification criteria:
- Build tested locally on Windows and Linux

Signed-off-by: Vladyslav Goncharuk <svlad1990@gmail.com>