### PR TITLE
Fix non-standard binary install destination

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,8 +67,8 @@ target_link_libraries (${TARGET_NAME}
     Qt5::SerialPort
 )
 
-install(TARGETS ${TARGET_NAME} DESTINATION deploy)
-install(DIRECTORY icon png svg DESTINATION deploy
+install(TARGETS ${TARGET_NAME} DESTINATION ${EXECUTABLE_INSTALLATION_PATH})
+install(DIRECTORY icon png svg DESTINATION ${RESOURCE_INSTALLATION_PATH}
         PATTERN icon/*.rc EXCLUDE )
 
 include (${CMAKE_SYSTEM_NAME}.cmake OPTIONAL)


### PR DESCRIPTION
Use the destination variables defined in the toplevel CMakeLists instead
of the hardcoded "deploy" directory. This makes the "install" target
behave in the standard CMake way, i.e. allows to relocate the whole
installation tree using CMAKE_INSTALL_PREFIX and find the binaries in
the expected place.

Signed-off-by: Oleg Kolosov <bazurbat@gmail.com>