### PR TITLE
Fix dock widgets hide restore

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -136,6 +136,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->actionToggle_PluginsEnabled->setChecked(ui->pluginsEnabled->isChecked());
     ui->actionToggle_SortByTimeEnabled->setChecked(ui->checkBoxSortByTime->isChecked());
     ui->actionSort_By_Timestamp->setChecked(ui->checkBoxSortByTimestamp->isChecked());
+    ui->actionProject->setChecked(ui->dockWidgetContents->isVisible());
+    ui->actionSearch_Results->setChecked(ui->dockWidgetSearchIndex->isVisible());
 
     newCompleter = new QCompleter(&m_CompleterModel,this);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1817,7 +1817,6 @@ void MainWindow::reloadLogFile(bool update, bool multithreaded)
     ui->tableView->selectionModel()->clear();
     m_searchtableModel->clear_SearchResults();
 
-    ui->dockWidgetSearchIndex->show();
     QString title = "Search Results";
     ui->dockWidgetSearchIndex->setWindowTitle(title);
 
@@ -2028,6 +2027,7 @@ void MainWindow::on_actionFindNext()
        }
     QString title = "Search Results";
     ui->dockWidgetSearchIndex->setWindowTitle(title);
+    ui->dockWidgetSearchIndex->show();
     m_CompleterModel.setStringList(list);
     searchTextbox->setCompleter(newCompleter);
 }


### PR DESCRIPTION
1. Do not raise search results panel every time the filters are updated

   If the user explicitly hid it they most likely prefer to keep it hidden. The panel will still be shown when the "FindNext" action is activated.

2. Sync view menu checkboxes with restored window state

   When the application is restarted the visibility state of the dock widgets does not reflect the checkboxes in the View menu. This will require activating menu items twice to make them in sync.