### PR TITLE
Fixed scroll in table view in case when Index column is hidden

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -393,6 +393,7 @@ private slots:
     void triggerPluginsAutoload();
 
     void onTableViewSelectionChanged(const QItemSelection & selected, const QItemSelection & deselected);
+    void onSearchresultsTableSelectionChanged(const QItemSelection & selected, const QItemSelection & deselected);
 
     void on_tableView_customContextMenuRequested(QPoint pos);
     void on_tableView_SearchIndex_customContextMenuRequested(QPoint pos);


### PR DESCRIPTION
Fixed scroll in table view in case when Index column is hidden; 
Disabled autoscroll to the right in search results

Signed-off-by: Andrey Sakun sakun.andrey@gmail.com