### PR TITLE
Search/Replace for filter configs

### DIFF
--- a/qdlt/qdltfilter.cpp
+++ b/qdlt/qdltfilter.cpp
@@ -48,13 +48,16 @@ QDltFilter& QDltFilter::operator= (QDltFilter const& _filter)
     ctid = _filter.ctid;
     header = _filter.header;
     payload = _filter.payload;
+    regex_search = _filter.regex_search;
+    regex_replace = _filter.regex_replace;
 
-    enableRegexp_Appid   = _filter.enableRegexp_Appid;
-    enableRegexp_Context = _filter.enableRegexp_Context;
-    enableRegexp_Header  = _filter.enableRegexp_Header;
-    enableRegexp_Payload = _filter.enableRegexp_Payload;
-    ignoreCase_Header    = _filter.ignoreCase_Header;
-    ignoreCase_Payload   = _filter.ignoreCase_Payload;
+    enableRegexp_Appid       = _filter.enableRegexp_Appid;
+    enableRegexp_Context     = _filter.enableRegexp_Context;
+    enableRegexp_Header      = _filter.enableRegexp_Header;
+    enableRegexp_Payload     = _filter.enableRegexp_Payload;
+    ignoreCase_Header        = _filter.ignoreCase_Header;
+    ignoreCase_Payload       = _filter.ignoreCase_Payload;
+    enableRegexSearchReplace = _filter.enableRegexSearchReplace;
 
     enableFilter = _filter.enableFilter;
     enableEcuid = _filter.enableEcuid;
@@ -93,6 +96,8 @@ void QDltFilter::clear()
     ctid.clear();
     header.clear();
     payload.clear();
+    regex_search.clear();
+    regex_replace.clear();
 
     enableRegexp_Appid = false;
     enableRegexp_Context = false;
@@ -110,6 +115,7 @@ void QDltFilter::clear()
     enableLogLevelMax = false;
     enableLogLevelMin = false;
     enableMarker = false;
+    enableRegexSearchReplace = false;
 
     filterColour = "#000000"; // QColor() default contructor initializes to an invalid color RGB 0,0,0
     logLevelMax = 6;
@@ -292,6 +298,14 @@ void QDltFilter::LoadFilterItem(QXmlStreamReader &xml)
     {
           payload = xml.readElementText();
     }
+    if(xml.name() == QString("regex_search"))
+    {
+          regex_search = xml.readElementText();
+    }
+    if(xml.name() == QString("regex_replace"))
+    {
+          regex_replace = xml.readElementText();
+    }
     if(xml.name() == QString("enableregexp"))    //legacy
     {
         enableRegexp_Appid   = xml.readElementText().toInt();
@@ -366,6 +380,10 @@ void QDltFilter::LoadFilterItem(QXmlStreamReader &xml)
     {
           enableMessageId = xml.readElementText().toInt();;
     }
+    if(xml.name() == QString("enableRegexSearchReplace"))
+    {
+          enableRegexSearchReplace = xml.readElementText().toInt();;
+    }
     if(xml.name() == QString("filterColour"))
     {
           filterColour = xml.readElementText();
@@ -399,6 +417,8 @@ void QDltFilter::SaveFilterItem(QXmlStreamWriter &xml)
     xml.writeTextElement("contextid",ctid);
     xml.writeTextElement("headertext",header);
     xml.writeTextElement("payloadtext",payload);
+    xml.writeTextElement("regex_search",regex_search);
+    xml.writeTextElement("regex_replace",regex_replace);
     xml.writeTextElement("messageIdMin",QString("%1").arg(messageIdMin));
     xml.writeTextElement("messageIdMax",QString("%1").arg(messageIdMax));
 
@@ -419,6 +439,7 @@ void QDltFilter::SaveFilterItem(QXmlStreamWriter &xml)
     xml.writeTextElement("enableLogLevelMax",QString("%1").arg(enableLogLevelMax));
     xml.writeTextElement("enableMarker",QString("%1").arg(enableMarker));
     xml.writeTextElement("enableMessageId",QString("%1").arg(enableMessageId));
+    xml.writeTextElement("enableRegexSearchReplace",QString("%1").arg(enableRegexSearchReplace));
 
     xml.writeTextElement("filterColour",filterColour);
 

--- a/qdlt/qdltfilter.h
+++ b/qdlt/qdltfilter.h
@@ -49,6 +49,8 @@ public:
     QString ctid;
     QString header;
     QString payload;
+    QString regex_search;
+    QString regex_replace;
 
     bool enableRegexp_Appid;
     bool enableRegexp_Context;
@@ -69,6 +71,7 @@ public:
     bool enableLogLevelMin;
     bool enableMarker;
     bool enableMessageId;
+    bool enableRegexSearchReplace;
 
     QString filterColour;
     int logLevelMax;

--- a/src/filterdialog.cpp
+++ b/src/filterdialog.cpp
@@ -33,6 +33,8 @@ FilterDialog::FilterDialog(QWidget *parent) :
     connect(ui->lineEdit_msgIdMax, SIGNAL(textChanged(const QString&)), this, SLOT(checkMsgIdValid(const QString&)));
     connect(ui->lineEdit_msgIdMin, SIGNAL(textChanged(const QString&)), this, SLOT(checkMsgIdValid(const QString&)));
     connect(ui->checkBoxMessageId, SIGNAL(stateChanged(int)), this, SLOT(on_checkboxMessageId_stateChanged(int)));
+    connect(ui->lineEditRegexSearch, SIGNAL(textChanged(const QString&)), this, SLOT(on_checkRegex(const QString&)));
+    connect(ui->lineEditRegexReplace, SIGNAL(textChanged(const QString&)), this, SLOT(on_checkRegex(const QString&)));
 
     ui->pushButton_c0->setStyleSheet ("QPushButton {background-color: rgb(255, 0  , 0  );} QPushButton:disabled {background-color: rgb(255, 255, 255);}");
     ui->pushButton_c1->setStyleSheet ("QPushButton {background-color: rgb(255, 255, 0  );} QPushButton:disabled {background-color: rgb(255, 255, 255);}");
@@ -361,6 +363,31 @@ bool FilterDialog::getEnableMarker(){
     return (ui->groupBox_marker->isCheckable()&&ui->groupBox_marker->isChecked());
 }
 
+void FilterDialog::setEnableRegexSearchReplace(bool state){
+    return ui->checkBoxRegexSearchReplace->setChecked(state);
+}
+
+bool FilterDialog::getEnableRegexSearchReplace(){
+    return ui->checkBoxRegexSearchReplace->checkState() == Qt::Checked;
+}
+
+void FilterDialog::setRegexSearchText(const QString& str){
+    ui->lineEditRegexSearch->setText(str);
+}
+
+QString FilterDialog::getRegexSearchText(){
+    return ui->lineEditRegexSearch->text();
+}
+
+void FilterDialog::setRegexReplaceText(const QString& str){
+    ui->lineEditRegexReplace->setText(str);
+}
+
+QString FilterDialog::getRegexReplaceText(){
+    return ui->lineEditRegexReplace->text();
+}
+
+
 void FilterDialog::on_buttonSelectColor_clicked()
 {
     QColor selectedBackgroundColor = QColorDialog::getColor(this->getFilterColour());
@@ -438,6 +465,14 @@ void FilterDialog::on_comboBoxLogLevelMax_currentIndexChanged(int )
 void FilterDialog::on_comboBoxLogLevelMin_currentIndexChanged(int )
 {
     ui->checkBoxLogLevelMin->setCheckState(Qt::Checked);
+}
+
+void FilterDialog::on_checkRegex(const QString&)
+{
+    if (ui->lineEditRegexSearch->text().length() || ui->lineEditRegexReplace->text().length())
+        ui->checkBoxRegexSearchReplace->setCheckState(Qt::Checked);
+    else
+        ui->checkBoxRegexSearchReplace->setCheckState(Qt::Unchecked);
 }
 
 void FilterDialog::validate()
@@ -616,7 +651,8 @@ void FilterDialog::checkMsgIdValid(const QString&)
                 );
 
 }
-void FilterDialog::on_checkboxMessageId_stateChanged(int state)
+
+void FilterDialog::on_checkboxMessageId_stateChanged(int)
     {
         checkMsgIdValid("");
     }

--- a/src/filterdialog.h
+++ b/src/filterdialog.h
@@ -118,6 +118,15 @@ public:
     void setEnableMarker(bool state);
     bool getEnableMarker();
 
+    void setEnableRegexSearchReplace(bool state);
+    bool getEnableRegexSearchReplace();
+
+    void setRegexSearchText(const QString&);
+    QString getRegexSearchText();
+
+    void setRegexReplaceText(const QString&);
+    QString getRegexReplaceText();
+
 private:
     Ui::FilterDialog *ui;
     unsigned int msgIdMin=0;
@@ -127,6 +136,7 @@ public slots:
     void on_comboBoxType_currentIndexChanged(int index);
     void checkMsgIdValid(const QString&);
     void on_checkboxMessageId_stateChanged(int state);
+    void on_checkRegex(const QString&);
     void validate();
 private slots:
     void on_lineEditApplicationId_textEdited(const QString &arg1);

--- a/src/filterdialog.ui
+++ b/src/filterdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>548</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -209,19 +209,10 @@
    </item>
    <item row="7" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="3" column="1" colspan="2">
-      <widget class="QLineEdit" name="lineEditHeaderText"/>
-     </item>
-     <item row="4" column="1" colspan="2">
-      <widget class="QLineEdit" name="lineEditPayloadText"/>
-     </item>
-     <item row="1" column="3">
-      <widget class="QCheckBox" name="checkBoxRegexp_Appid">
-       <property name="toolTip">
-        <string>Enable this option, to use regular expressions for AppId  text.</string>
-       </property>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="checkBoxHeaderText">
        <property name="text">
-        <string>RegExp</string>
+        <string>Header Text:</string>
        </property>
       </widget>
      </item>
@@ -235,6 +226,13 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="checkBoxMessageId">
+       <property name="text">
+        <string>Message Id</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1" colspan="2">
       <widget class="QLineEdit" name="lineEditContextId">
        <property name="maxLength">
@@ -242,129 +240,8 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
-      <widget class="QCheckBox" name="checkBox_IgnoreCase_Header">
-       <property name="toolTip">
-        <string>Enable this option, to ignore case on header search expression</string>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>ic</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QCheckBox" name="checkBoxCtrlMsgs">
-       <property name="text">
-        <string>Control Messages</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="checkBoxContextId">
-       <property name="text">
-        <string>Context Id:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="checkBoxEcuId">
-       <property name="text">
-        <string>ECU Id:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="checkBoxApplicationId">
-       <property name="text">
-        <string>Application Id:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="checkBoxHeaderText">
-       <property name="text">
-        <string>Header Text:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QComboBox" name="comboBoxLogLevelMax">
-       <item>
-        <property name="text">
-         <string>off</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>fatal</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>error</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>warn</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>info</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>debug</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>verbose</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QCheckBox" name="checkBoxLogLevelMax">
-       <property name="text">
-        <string>Log Level Max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QCheckBox" name="checkBoxLogLevelMin">
-       <property name="text">
-        <string>Log Level Min</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="checkBoxPayloadText">
-       <property name="text">
-        <string>Payload Text:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QLineEdit" name="lineEditEcuId"/>
-     </item>
-     <item row="4" column="4">
-      <widget class="QCheckBox" name="checkBox_IgnoreCase_Payload">
-       <property name="toolTip">
-        <string>Enable this option, to ignore case on payload search expression</string>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>ic</string>
-       </property>
-      </widget>
+     <item row="1" column="1" colspan="2">
+      <widget class="QLineEdit" name="lineEditApplicationId"/>
      </item>
      <item row="3" column="3">
       <widget class="QCheckBox" name="checkBoxRegexp_Header">
@@ -376,21 +253,29 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="3">
-      <widget class="QCheckBox" name="checkBoxRegexp_Payload">
-       <property name="toolTip">
-        <string>Enable this option, to use regular expressions for payload text.</string>
-       </property>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="checkBoxContextId">
        <property name="text">
-        <string>RegExp</string>
+        <string>Context Id:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="2">
-      <widget class="QLineEdit" name="lineEditApplicationId"/>
+     <item row="9" column="0">
+      <widget class="QCheckBox" name="checkBoxCtrlMsgs">
+       <property name="text">
+        <string>Control Messages</string>
+       </property>
+      </widget>
      </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="comboBoxLogLevelMin">
+     <item row="7" column="0">
+      <widget class="QCheckBox" name="checkBoxLogLevelMin">
+       <property name="text">
+        <string>Log Level Min</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QComboBox" name="comboBoxLogLevelMax">
        <item>
         <property name="text">
          <string>off</string>
@@ -441,11 +326,98 @@
        </property>
       </spacer>
      </item>
-
-     <item row="5" column="0">
-      <widget class="QCheckBox" name="checkBoxMessageId">
+     <item row="3" column="1" colspan="2">
+      <widget class="QLineEdit" name="lineEditHeaderText"/>
+     </item>
+     <item row="4" column="3">
+      <widget class="QCheckBox" name="checkBoxRegexp_Payload">
+       <property name="toolTip">
+        <string>Enable this option, to use regular expressions for payload text.</string>
+       </property>
        <property name="text">
-        <string>Message Id</string>
+        <string>RegExp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="2">
+      <widget class="QLineEdit" name="lineEditEcuId"/>
+     </item>
+     <item row="4" column="1" colspan="2">
+      <widget class="QLineEdit" name="lineEditPayloadText"/>
+     </item>
+     <item row="4" column="4">
+      <widget class="QCheckBox" name="checkBox_IgnoreCase_Payload">
+       <property name="toolTip">
+        <string>Enable this option, to ignore case on payload search expression</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ic</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QCheckBox" name="checkBoxRegexp_Appid">
+       <property name="toolTip">
+        <string>Enable this option, to use regular expressions for AppId  text.</string>
+       </property>
+       <property name="text">
+        <string>RegExp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QCheckBox" name="checkBoxLogLevelMax">
+       <property name="text">
+        <string>Log Level Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="comboBoxLogLevelMin">
+       <item>
+        <property name="text">
+         <string>off</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>fatal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>error</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>warn</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>info</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>debug</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>verbose</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="checkBoxApplicationId">
+       <property name="text">
+        <string>Application Id:</string>
        </property>
       </widget>
      </item>
@@ -475,6 +447,20 @@
         <widget class="QLineEdit" name="lineEdit_msgIdMax"/>
        </item>
       </layout>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkBoxEcuId">
+       <property name="text">
+        <string>ECU Id:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="checkBoxPayloadText">
+       <property name="text">
+        <string>Payload Text:</string>
+       </property>
+      </widget>
      </item>
      <item row="6" column="1" colspan="4">
       <widget class="QPlainTextEdit" name="plainTextEdit_msgIdRule">
@@ -526,6 +512,32 @@
         <set>Qt::TextSelectableByMouse</set>
        </property>
       </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="QCheckBox" name="checkBox_IgnoreCase_Header">
+       <property name="toolTip">
+        <string>Enable this option, to ignore case on header search expression</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ic</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QCheckBox" name="checkBoxRegexSearchReplace">
+       <property name="text">
+        <string>Regex Replace</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QLineEdit" name="lineEditRegexSearch"/>
+     </item>
+     <item row="10" column="2">
+      <widget class="QLineEdit" name="lineEditRegexReplace"/>
      </item>
     </layout>
    </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6195,6 +6195,8 @@ void MainWindow::filterDialogWrite(FilterDialog &dlg,FilterItem* item)
     dlg.setContextId(item->filter.ctid);
     dlg.setHeaderText(item->filter.header);
     dlg.setPayloadText(item->filter.payload);
+    dlg.setRegexSearchText(item->filter.regex_search);
+    dlg.setRegexReplaceText(item->filter.regex_replace);
 
     dlg.setEnableRegexp_Appid(item->filter.enableRegexp_Appid);
     dlg.setEnableRegexp_Context(item->filter.enableRegexp_Context);
@@ -6213,6 +6215,7 @@ void MainWindow::filterDialogWrite(FilterDialog &dlg,FilterItem* item)
     dlg.setEnableLogLevelMin(item->filter.enableLogLevelMin);
     dlg.setEnableMarker(item->filter.enableMarker);
     dlg.setEnableMessageId(item->filter.enableMessageId);
+    dlg.setEnableRegexSearchReplace(item->filter.enableRegexSearchReplace);
 
     dlg.setFilterColour(item->filter.filterColour);
 
@@ -6234,6 +6237,8 @@ void MainWindow::filterDialogRead(FilterDialog &dlg,FilterItem* item)
     item->filter.ctid = dlg.getContextId();
     item->filter.header = dlg.getHeaderText();
     item->filter.payload = dlg.getPayloadText();
+    item->filter.regex_search = dlg.getRegexSearchText();
+    item->filter.regex_replace = dlg.getRegexReplaceText();
 
     item->filter.enableRegexp_Appid = dlg.getEnableRegexp_Appid();
     item->filter.enableRegexp_Context = dlg.getEnableRegexp_Context();
@@ -6251,7 +6256,8 @@ void MainWindow::filterDialogRead(FilterDialog &dlg,FilterItem* item)
     item->filter.enableLogLevelMax = dlg.getEnableLogLevelMax();
     item->filter.enableLogLevelMin = dlg.getEnableLogLevelMin();
     item->filter.enableMarker = dlg.getEnableMarker();
-    item->filter.enableMessageId=dlg.getEnableMessageId();
+    item->filter.enableMessageId = dlg.getEnableMessageId();
+    item->filter.enableRegexSearchReplace = dlg.getEnableRegexSearchReplace();
 
     item->filter.filterColour = dlg.getFilterColour();
     item->filter.logLevelMax = dlg.getLogLevelMax();

--- a/src/regex_search_replace.h
+++ b/src/regex_search_replace.h
@@ -3,16 +3,16 @@
 
 #include "project.h"
 #include <regex>
+#include <stdlib.h>
 
-static void apply_regex(QDltArgument &argument, const QString& regex_search, const QString& regex_replace)
+
+static void apply_regex_string(QString &data, const QString& regex_search, const QString& regex_replace)
 {
-    QByteArray argument_data_to_decode = argument.getData();
-    std::string payload_str = argument_data_to_decode.toStdString();
-
     std::regex regex(regex_search.toStdString());
-    payload_str = std::regex_replace(payload_str, regex, regex_replace.toStdString());
 
-    argument.setData(QByteArray::fromStdString(payload_str));
+    std::string payload_str = std::regex_replace(data.toStdString(), regex, regex_replace.toStdString());
+
+    data = QString::fromStdString(payload_str);
 }
 
 #endif // REGEX_SEARCH_REPLACE_H

--- a/src/regex_search_replace.h
+++ b/src/regex_search_replace.h
@@ -1,0 +1,18 @@
+#ifndef REGEX_SEARCH_REPLACE_H
+#define REGEX_SEARCH_REPLACE_H
+
+#include "project.h"
+#include <regex>
+
+static void apply_regex(QDltArgument &argument, const QString& regex_search, const QString& regex_replace)
+{
+    QByteArray argument_data_to_decode = argument.getData();
+    std::string payload_str = argument_data_to_decode.toStdString();
+
+    std::regex regex(regex_search.toStdString());
+    payload_str = std::regex_replace(payload_str, regex, regex_replace.toStdString());
+
+    argument.setData(QByteArray::fromStdString(payload_str));
+}
+
+#endif // REGEX_SEARCH_REPLACE_H

--- a/src/searchtablemodel.cpp
+++ b/src/searchtablemodel.cpp
@@ -20,7 +20,7 @@
 
 #include "fieldnames.h"
 #include "dltuiutils.h"
-
+#include "regex_search_replace.h"
 
 SearchTableModel::SearchTableModel(const QString &,QObject *parent) :
     QAbstractTableModel(parent)
@@ -34,8 +34,6 @@ SearchTableModel::~SearchTableModel()
 {
 
 }
-
-
 
 QVariant SearchTableModel::data(const QModelIndex &index, int role) const
 {
@@ -66,6 +64,24 @@ QVariant SearchTableModel::data(const QModelIndex &index, int role) const
 
         if(QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool())
             pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
+
+        if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
+        {
+            for(int num = 0; num < project->filter->topLevelItemCount (); num++)
+            {
+                FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
+                if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
+
+                    for(int i=0; i<msg.getNumberOfArguments(); i++){
+                        QDltArgument arg;
+                        msg.getArgument(i, arg);
+                        apply_regex(arg, item->filter.regex_search, item->filter.regex_replace);
+                        msg.removeArgument(i);
+                        msg.addArgument(arg, i);
+                    }
+                }
+            }
+        }
 
         switch(index.column())
         {

--- a/src/searchtablemodel.cpp
+++ b/src/searchtablemodel.cpp
@@ -65,24 +65,7 @@ QVariant SearchTableModel::data(const QModelIndex &index, int role) const
         if(QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool())
             pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
 
-        if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
-        {
-            for(int num = 0; num < project->filter->topLevelItemCount (); num++)
-            {
-                FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
-                if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
-
-                    for(int i=0; i<msg.getNumberOfArguments(); i++){
-                        QDltArgument arg;
-                        msg.getArgument(i, arg);
-                        apply_regex(arg, item->filter.regex_search, item->filter.regex_replace);
-                        msg.removeArgument(i);
-                        msg.addArgument(arg, i);
-                    }
-                }
-            }
-        }
-
+        QString visu_data;
         switch(index.column())
         {
         case FieldNames::Index:
@@ -176,7 +159,17 @@ QVariant SearchTableModel::data(const QModelIndex &index, int role) const
             return QString("%1").arg(msg.getNumberOfArguments());
         case FieldNames::Payload:
             /* display payload */
-            return msg.toStringPayload().trimmed();
+            visu_data = msg.toStringPayload().trimmed();
+            if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
+            {
+                for(int num = 0; num < project->filter->topLevelItemCount (); num++) {
+                    FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
+                    if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
+                        apply_regex_string(visu_data, item->filter.regex_search, item->filter.regex_replace);
+                    }
+                }
+            }
+            return visu_data;
         case FieldNames::MessageId:
             return QString().sprintf(project->settings->msgIdFormat.toLatin1(),msg.getMessageId());
         default:

--- a/src/src.pro
+++ b/src/src.pro
@@ -181,6 +181,7 @@ HEADERS += mainwindow.h \
     dltfileindexerthread.h \
     dltfileindexerdefaultfilterthread.h \
     mcudpsocket.h \
+    regex_search_replace.h
 
 # Compile these UI files
 FORMS += mainwindow.ui \

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -144,25 +144,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
               }
          }
 
-
-         if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
-         {
-             for(int num = 0; num < project->filter->topLevelItemCount (); num++)
-             {
-                 FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
-                 if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
-
-                     for(int i=0; i<msg.getNumberOfArguments(); i++){
-                         QDltArgument arg;
-                         msg.getArgument(i, arg);
-                         apply_regex(arg, item->filter.regex_search, item->filter.regex_replace);
-                         msg.removeArgument(i);
-                         msg.addArgument(arg, i);
-                     }
-                 }
-             }
-         }
-
+         QString visu_data;
          switch(index.column())
          {
          case FieldNames::Index:
@@ -265,7 +247,19 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
                  return QString("Logging only Mode! Disable in Project Settings!");
              }
              /* display payload */
-             return msg.toStringPayload().trimmed().replace('\n', ' ');
+             visu_data = msg.toStringPayload().trimmed().replace('\n', ' ');
+
+             if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
+             {
+                 for(int num = 0; num < project->filter->topLevelItemCount (); num++) {
+                     FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
+                     if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
+                         apply_regex_string(visu_data, item->filter.regex_search, item->filter.regex_replace);
+                     }
+                 }
+             }
+
+             return visu_data;
          case FieldNames::MessageId:
              return QString().sprintf(project->settings->msgIdFormat.toLatin1() ,msg.getMessageId());
          default:

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -25,7 +25,7 @@
 #include "fieldnames.h"
 #include "dltuiutils.h"
 #include "dlt_protocol.h"
-
+#include "regex_search_replace.h"
 
 static long int lastrow = -1; // necessary because object tablemodel can not be changed, so no member variable can be used
 char buffer[DLT_VIEWER_LIST_BUFFER_SIZE];
@@ -77,6 +77,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
  {
      return DLT_VIEWER_COLUMN_COUNT+project->settings->showArguments;
  }
+
 
  QVariant TableModel::data(const QModelIndex &index, int role) const
  {
@@ -143,6 +144,24 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
               }
          }
 
+
+         if((QDltSettingsManager::getInstance()->value("startup/filtersEnabled", true).toBool()))
+         {
+             for(int num = 0; num < project->filter->topLevelItemCount (); num++)
+             {
+                 FilterItem *item = (FilterItem*)project->filter->topLevelItem(num);
+                 if(item->checkState(0) == Qt::Checked && item->filter.enableRegexSearchReplace) {
+
+                     for(int i=0; i<msg.getNumberOfArguments(); i++){
+                         QDltArgument arg;
+                         msg.getArgument(i, arg);
+                         apply_regex(arg, item->filter.regex_search, item->filter.regex_replace);
+                         msg.removeArgument(i);
+                         msg.addArgument(arg, i);
+                     }
+                 }
+             }
+         }
 
          switch(index.column())
          {


### PR DESCRIPTION
This PR allows Filters to search/replace within DLT data.

Using the two new fields `regex_search` and `regex_replace` in the filter config, a filter can now not only be used to highlight messages in the view, but also to modify the content based on the specified rule. 

This can be very helpful when dealing with known patterns, like e.g. insert markers, etc.