### PR TITLE
Sort by time/timestamp keeps index order

### DIFF
--- a/src/dltfileindexer.cpp
+++ b/src/dltfileindexer.cpp
@@ -15,11 +15,20 @@ extern "C" {
     #include "dlt_user.h"
 }
 
-DltFileIndexerKey::DltFileIndexerKey(time_t time,unsigned int microseconds,unsigned int timestamp)
+DltFileIndexerKey::DltFileIndexerKey(time_t time, unsigned int microseconds, int index)
+    : timestamp(0)
 {
     this->time = time;
     this->microseconds = microseconds;
+    this->index = index;
+}
+
+DltFileIndexerKey::DltFileIndexerKey(unsigned int timestamp, int index)
+    : time(0)
+    , microseconds(0)
+{
     this->timestamp = timestamp;
+    this->index = index;
 }
 
 DltFileIndexer::DltFileIndexer(QObject *parent) :

--- a/src/dltfileindexer.h
+++ b/src/dltfileindexer.h
@@ -16,7 +16,8 @@
 class DltFileIndexerKey
 {
 public:
-    DltFileIndexerKey(time_t time,unsigned int microseconds,unsigned int timestamp);
+    DltFileIndexerKey(time_t time, unsigned int microseconds, int index);
+    DltFileIndexerKey(unsigned int timestamp, int index);
 
     friend bool operator< (const DltFileIndexerKey &key1, const DltFileIndexerKey &key2);
 
@@ -24,19 +25,30 @@ private:
     time_t time;
     unsigned int microseconds;
     unsigned int timestamp;
+    int index;
 };
 
 inline bool operator< (const DltFileIndexerKey &key1, const DltFileIndexerKey &key2)
 {
-    if(key1.timestamp==0 && key2.timestamp==0)
+    if (key1.timestamp == 0 && key2.timestamp == 0)
     {
-        if(key1.time<key2.time)
+        if (key1.time < key2.time)
             return true;
-        if(key1.time>key2.time)
+        if (key1.time > key2.time)
             return false;
-        return (key1.microseconds<key2.microseconds);
+        if (key1.microseconds < key2.microseconds)
+            return true;
+        if (key1.microseconds > key2.microseconds)
+            return false;
     }
-    return (key1.timestamp<key2.timestamp);
+    else
+    {
+        if (key1.timestamp < key2.timestamp)
+            return true;
+        if (key1.timestamp > key2.timestamp)
+            return false;
+    }
+    return (key1.index < key2.index);
 }
 
 class DltFileIndexer : public QThread
@@ -156,7 +168,7 @@ private:
 
     // filtered index
     QVector<qint64> indexFilterList;
-    QMultiMap<DltFileIndexerKey,qint64> indexFilterListSorted;
+    QMap<DltFileIndexerKey,qint64> indexFilterListSorted;
 
     // getLogInfoList
     QList<int> getLogInfoList;

--- a/src/dltfileindexerthread.cpp
+++ b/src/dltfileindexerthread.cpp
@@ -10,7 +10,7 @@ DltFileIndexerThread::DltFileIndexerThread
         bool sortByTimeEnabled,
         bool sortByTimestampEnabled,
         QVector<qint64> *indexFilterList,
-        QMultiMap<DltFileIndexerKey,qint64> *indexFilterListSorted,
+        QMap<DltFileIndexerKey,qint64> *indexFilterListSorted,
         QDltPluginManager *pluginManager,
         QList<QDltPlugin*> *activeViewerPlugins,
         bool silentMode
@@ -128,11 +128,11 @@ void DltFileIndexerThread::processMessage(QSharedPointer<QDltMsg> &msg, int inde
     {
         if(sortByTimeEnabled)
          {
-            indexFilterListSorted->insert(DltFileIndexerKey(msg->getTime(), msg->getMicroseconds(),0), index);
+            indexFilterListSorted->insert(DltFileIndexerKey(msg->getTime(), msg->getMicroseconds(), index), index);
          }
         else if(sortByTimestampEnabled)
          {
-            indexFilterListSorted->insert(DltFileIndexerKey(0, 0,msg->getTimestamp()), index);
+            indexFilterListSorted->insert(DltFileIndexerKey(msg->getTimestamp(), index), index);
          }
         else
          {

--- a/src/dltfileindexerthread.h
+++ b/src/dltfileindexerthread.h
@@ -9,7 +9,7 @@ class DltFileIndexerThread :public QThread
 {
     Q_OBJECT
 public:
-    DltFileIndexerThread(DltFileIndexer *indexer, QDltFilterList *filterList, bool sortByTimeEnabled, bool sortByTimestampEnabled, QVector<qint64> *indexFilterList, QMultiMap<DltFileIndexerKey,qint64> *indexFilterListSorted, QDltPluginManager *pluginManager, QList<QDltPlugin*> *activeViewerPlugins, bool silentMode);
+    DltFileIndexerThread(DltFileIndexer *indexer, QDltFilterList *filterList, bool sortByTimeEnabled, bool sortByTimestampEnabled, QVector<qint64> *indexFilterList, QMap<DltFileIndexerKey,qint64> *indexFilterListSorted, QDltPluginManager *pluginManager, QList<QDltPlugin*> *activeViewerPlugins, bool silentMode);
     ~DltFileIndexerThread();
     void enqueueMessage(const QSharedPointer<QDltMsg> &msg, int index);
     void processMessage(QSharedPointer<QDltMsg> &msg, int index);
@@ -25,7 +25,7 @@ private:
     bool sortByTimestampEnabled;
 
     QVector<qint64> *indexFilterList;
-    QMultiMap<DltFileIndexerKey,qint64> *indexFilterListSorted;
+    QMap<DltFileIndexerKey,qint64> *indexFilterListSorted;
 
     QDltPluginManager *pluginManager;
     QList<QDltPlugin*> *activeViewerPlugins;


### PR DESCRIPTION
For messages that have the exact same time/timestamp, we keep the same order for the messages by using their index.

Fixes #124

**This has not been tested**. @alexmucde if you can help with a test build it would be great.