### PR TITLE
Enable optional append for default filters

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -510,7 +510,6 @@ void MainWindow::initFileHandling()
     ui->checkBoxSortByTimestamp->setEnabled(ui->filtersEnabled->isChecked());
     ui->checkBoxSortByTimestamp->setChecked(QDltSettingsManager::getInstance()->value("startup/sortByTimestampEnabled", false).toBool());
 
-
     /* Process Project */
     if(QDltOptManager::getInstance()->isProjectFile())
     {
@@ -7211,7 +7210,7 @@ void MainWindow::on_comboBoxFilterSelection_activated(const QString &arg1)
     }
 
     /* load current selected filter */
-    if(!arg1.isEmpty() && project.LoadFilter(arg1,true))
+    if(!arg1.isEmpty() && project.LoadFilter(arg1,!ui->checkBoxAppendDefaultFilter->isChecked()))
     {
         workingDirectory.setDlfDirectory(QFileInfo(arg1).absolutePath());
         setCurrentFilters(arg1);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -402,6 +402,16 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="2">
+         <widget class="QCheckBox" name="checkBoxAppendDefaultFilter">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Append Filter</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -402,16 +402,6 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
-         <widget class="QCheckBox" name="checkBoxAppendDefaultFilter">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Append Filter</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </widget>
      </item>
@@ -594,7 +584,7 @@
           <number>3</number>
          </property>
          <property name="spacing">
-          <number>3</number>
+          <number>5</number>
          </property>
          <item row="0" column="0">
           <widget class="QComboBox" name="comboBoxFilterSelection">
@@ -619,7 +609,7 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
+             <width>75</width>
              <height>16777215</height>
             </size>
            </property>
@@ -631,7 +621,17 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0" colspan="2">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="checkBoxAppendDefaultFilter">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Append Filter (instead of replace)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
           <widget class="FilterTreeWidget" name="filterWidget">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">


### PR DESCRIPTION
If the checkbox is activated and default filter is selected it is
appended rather than replacing the previous filters.

Fixes #128