### PR TITLE
Fix filter load in case of error

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7252,10 +7252,6 @@ void MainWindow::on_comboBoxFilterSelection_activated(const QString &arg1)
         ui->tabWidget->setCurrentWidget(ui->tabPFilter);
         on_filterWidget_itemSelectionChanged();
     }
-    else
-    {
-        QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
-    }
 }
 
 void MainWindow::on_actionDefault_Filter_Reload_triggered()

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1102,12 +1102,13 @@ bool Project::LoadFilter(QString filename, bool replace){
     {
         if ( QDltOptManager::getInstance()->issilentMode() == false )
         {
-        QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
+            QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
         }
         else
         {
             qDebug() << "Loading" << filterList.getFilename() << " DLT Filter file failed !";
         }
+        return false;
     }
 
 


### PR DESCRIPTION
If a corrupted file has been passed to LoadFilter it still tried to load
the filters after notifying the loading of the file failed. This caused
a crash. Also the duplicate Messagebox has been removed.

Signed-off-by: Matthias Bilger <matthias@bilger.info>