### PR TITLE
Set default CMAKE_BUILD_TYPE for single configuration builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif()
+
 set(QT_VERSION_REQ "5")
 
 find_package(Qt5 ${QT_VERSION_REQ} REQUIRED COMPONENTS Core Network Widgets SerialPort PrintSupport)


### PR DESCRIPTION
Currently there is no build type set resulting in neither optimization
nor debug settings enabled. This applies to single configuration
generators that are the default on Linux systems.

Set to Release by default to get an optimized build. This results in
much higher performance and is therefore a good default for most
regular users.