### PR TITLE
Remove wrong (swapped) clone commands for macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -149,8 +149,6 @@ Sometimes building with Cmake or in Qt Creator leads to Plugins not working in  
 Building with qmake in release version gets rid of this problem.
 Steps to follow:
 
-* cd dlt-viewer
-* git clone https://github.com/GENIVI/dlt-viewer.git
 * mkdir build
 * cd build
 * <path to Qt folder>/Qt/5.X/gcc_64/bin/qmake <path to BuildDltViewer.pro>/BuildDltViewer.pro -r


### PR DESCRIPTION
I recommend not to explain git fundamental basics, btw the commands are wrong, they should be swapped.
Conclusion: it's just noise