### PR TITLE
New Connection type Serial ASCII

### DIFF
--- a/qdlt/qdltconnection.cpp
+++ b/qdlt/qdltconnection.cpp
@@ -68,6 +68,7 @@ void QDltConnection::clear()
     bytesReceived = 0;
     bytesError = 0;
     syncFound = 0;
+    messageCounter = 0;
 }
 
 void QDltConnection::add(const QByteArray &bytes)
@@ -79,7 +80,7 @@ void QDltConnection::add(const QByteArray &bytes)
     dataView.align(data);
 }
 
-bool QDltConnection::parse(QDltMsg &msg)
+bool QDltConnection::parseDlt(QDltMsg &msg)
 {
     /* if sync to serial header search for header */
     int found = 0;
@@ -194,3 +195,66 @@ bool QDltConnection::parse(QDltMsg &msg)
     return true;
 }
 
+bool QDltConnection::parseAscii(QDltMsg &msg)
+{
+    bool success = false;
+
+    /* Use primitive buffer for faster access */
+    int cbuf_sz = dataView.size();
+    const char *cbuf = dataView.constData();
+
+    /* find end of line in buffer */
+    for(int num=0;num<cbuf_sz;num++) {
+        if(cbuf[num] == '\r' || cbuf[num] == '\n')
+        {
+            // end of line found
+
+            // check if line is empty, do not store empty lines
+            if(num!=0)
+            {
+                // set parameters of DLT message to be generated
+                msg.clear();
+                msg.setEcuid("");
+                msg.setApid("SER");
+                msg.setCtid("ASC");
+                msg.setMode(QDltMsg::DltModeVerbose);
+                msg.setType(QDltMsg::DltTypeLog);
+                msg.setSubtype(QDltMsg::DltLogInfo);
+                msg.setMessageCounter(messageCounter++);
+                msg.setNumberOfArguments(1);
+
+                // add one argument as String
+                QDltArgument arg;
+                arg.setTypeInfo(QDltArgument::DltTypeInfoStrg);
+                arg.setEndianness(QDltArgument::DltEndiannessLittleEndian);
+                arg.setOffsetPayload(0);
+                arg.setData(QByteArray(cbuf,num)+QByteArray("",1));
+                msg.addArgument(arg);
+
+                // generate binary payload and header of DLT message
+                msg.genMsg();
+
+                // succesful found a new line to be written as DLT message
+                success = true;
+            }
+
+            // remove parsed line from buffer
+            if( (num < (cbuf_sz-1)) && (cbuf[num+1] == '\n' || cbuf[num+1] == '\r'))
+            {
+                // \n and \r found, remove two additional characters
+                dataView.advance(num+2);
+            }
+            else
+            {
+                // only \n or \r found, remove only one character
+                dataView.advance(num+1);
+            }
+
+            // msg read successful
+            return success;
+        }
+    }
+
+    // no message found
+    return success;
+}

--- a/qdlt/qdltconnection.h
+++ b/qdlt/qdltconnection.h
@@ -99,7 +99,8 @@ public:
     void setSyncSerialHeader(bool _syncSerialHeader);
     bool getSyncSerialHeader() const;
 
-    bool parse(QDltMsg &msg);
+    bool parseDlt(QDltMsg &msg);
+    bool parseAscii(QDltMsg &msg);
 
     void clear();
     void add(const QByteArray &bytes);
@@ -116,7 +117,9 @@ protected:
     bool sendSerialHeader;
     bool syncSerialHeader;
 
+private:
 
+    unsigned char messageCounter;
 
 };
 

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -628,3 +628,89 @@ QString QDltMsg::toStringPayload() const
 
     return text;
 }
+
+void QDltMsg::genMsg()
+{
+    DltStandardHeader standardheader;
+    DltStandardHeaderExtra headerextra;
+    DltExtendedHeader extendedheader;
+    QDltArgument argument;
+
+    // clear existing payload
+    payload.clear();
+
+    // Generate payload for all arguments
+    for(int num=0;num<arguments.size();num++) {
+        if(getArgument(num,argument)) {
+            argument.getArgument(payload,true);
+        }
+
+    }
+
+    // set payload size
+    payloadSize = payload.size();
+
+    // clear existing header
+    header.clear();
+
+    // write standardheader
+    standardheader.htyp = 0x01 << 5; /* intialise with version number 0x1 */
+    if(endianness == DltEndiannessBigEndian) {
+        standardheader.htyp |= DLT_HTYP_MSBF;
+    }
+    if(mode == DltModeVerbose) {
+        standardheader.len = DLT_SWAP_16(sizeof(DltStandardHeader) + sizeof(DltExtendedHeader) + payload.size());
+        standardheader.htyp |= DLT_HTYP_UEH;
+        if(!ecuid.isEmpty()) {
+            standardheader.htyp |= DLT_HTYP_WEID;
+            standardheader.len += sizeof(headerextra.ecu);
+        }
+        if(sessionid!=0) {
+            standardheader.htyp |= DLT_HTYP_WSID;
+            standardheader.len += sizeof(headerextra.seid);
+        }
+        if(timestamp!=0) {
+            standardheader.htyp |= DLT_HTYP_WTMS;
+            standardheader.len += sizeof(headerextra.tmsp);
+        }
+    }
+    else {
+        standardheader.len = DLT_SWAP_16(sizeof(DltStandardHeader) + payload.size());
+    }
+    standardheader.mcnt = messageCounter;
+    header += QByteArray((const char *)&standardheader,sizeof(DltStandardHeader));
+
+    // write standard header extra
+    if(mode == DltModeVerbose) {
+        if(!ecuid.isEmpty()) {
+            strncpy(headerextra.ecu,ecuid.toLatin1().constData(),ecuid.size()>3?4:ecuid.size()+1);
+            header += QByteArray((const char *)&(headerextra.ecu),sizeof(headerextra.ecu));
+        }
+        if(sessionid!=0) {
+            headerextra.seid = DLT_SWAP_32(sessionid);
+            header += QByteArray((const char *)&(headerextra.seid),sizeof(headerextra.seid));
+        }
+        if(timestamp!=0) {
+            headerextra.tmsp = DLT_SWAP_32(timestamp);
+            header += QByteArray((const char *)&(headerextra.tmsp),sizeof(headerextra.tmsp));
+        }
+    }
+
+    // write extendedheader
+    if(mode == DltModeVerbose) {
+        strncpy(extendedheader.apid,apid.toLatin1().constData(),apid.size()>3?4:apid.size()+1);
+        strncpy(extendedheader.ctid,ctid.toLatin1().constData(),ctid.size()>3?4:ctid.size()+1);
+        extendedheader.msin = 0;
+        if(mode == DltModeVerbose) {
+            extendedheader.msin |= DLT_MSIN_VERB;
+        }
+        extendedheader.msin |= (((unsigned char)type) << 1) & DLT_MSIN_MSTP;
+        extendedheader.msin |= (((unsigned char)subtype) << 4) & DLT_MSIN_MTIN;
+        extendedheader.noar = numberOfArguments;
+        header += QByteArray((const char *)&extendedheader,sizeof(DltExtendedHeader));
+    }
+
+    // set header size
+    headerSize = header.size();
+
+}

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -659,7 +659,7 @@ void QDltMsg::genMsg()
         standardheader.htyp |= DLT_HTYP_MSBF;
     }
     if(mode == DltModeVerbose) {
-        standardheader.len = DLT_SWAP_16(sizeof(DltStandardHeader) + sizeof(DltExtendedHeader) + payload.size());
+        standardheader.len = DLT_HTOBE_16(sizeof(DltStandardHeader) + sizeof(DltExtendedHeader) + payload.size());
         standardheader.htyp |= DLT_HTYP_UEH;
         if(!ecuid.isEmpty()) {
             standardheader.htyp |= DLT_HTYP_WEID;
@@ -675,7 +675,7 @@ void QDltMsg::genMsg()
         }
     }
     else {
-        standardheader.len = DLT_SWAP_16(sizeof(DltStandardHeader) + payload.size());
+        standardheader.len = DLT_HTOBE_16(sizeof(DltStandardHeader) + payload.size());
     }
     standardheader.mcnt = messageCounter;
     header += QByteArray((const char *)&standardheader,sizeof(DltStandardHeader));
@@ -687,11 +687,11 @@ void QDltMsg::genMsg()
             header += QByteArray((const char *)&(headerextra.ecu),sizeof(headerextra.ecu));
         }
         if(sessionid!=0) {
-            headerextra.seid = DLT_SWAP_32(sessionid);
+            headerextra.seid = DLT_HTOBE_32(sessionid);
             header += QByteArray((const char *)&(headerextra.seid),sizeof(headerextra.seid));
         }
         if(timestamp!=0) {
-            headerextra.tmsp = DLT_SWAP_32(timestamp);
+            headerextra.tmsp = DLT_HTOBE_32(timestamp);
             header += QByteArray((const char *)&(headerextra.tmsp),sizeof(headerextra.tmsp));
         }
     }

--- a/qdlt/qdltmsg.h
+++ b/qdlt/qdltmsg.h
@@ -299,11 +299,18 @@ public:
     */
     void setNumberOfArguments(unsigned char noargs) { numberOfArguments = noargs; }
 
-    //! Get the complete header of the DLT message.
+    //! Get the binary header of the DLT message.
     /*!
       \return Byte Array containing the complete header of the DLT message.
     */
     QByteArray getHeader() const { return header; }
+
+    //! Set the binary header of the DLT message.
+    /*!
+      Be careful with this function, binary data and interpreted data will not be in sync anymore.
+      \param data The new header of the DLT message
+    */
+    void setHeader(QByteArray &data) { header = data; }
 
     //! Get the size of the header.
     /*!
@@ -312,11 +319,25 @@ public:
     */
     int getHeaderSize() const { return headerSize; }
 
-    //! Get the complete payload of the DLT message.
+    //! Get the binary payload of the DLT message.
     /*!
       \return Byte Array containing the complete payload of the DLT message.
     */
     QByteArray getPayload() const { return payload; }
+
+    //! Set the binary payload of the DLT message.
+    /*!
+      Be careful with this function, binary data and interpreted data will not be in sync anymore.
+      \param data The new payload of the DLT message
+    */
+    void setPayload(QByteArray &data) { payload = data; }
+
+    //! Generate binary header and payload.
+    /*!
+      This function will generate first the binary payload from the argument list of the DLt message.
+      In a second step it will generate the binary header from all information in the DLT message.
+    */
+    void genMsg();
 
     //! Get the size of the payload.
     /*!

--- a/src/ecudialog.cpp
+++ b/src/ecudialog.cpp
@@ -388,11 +388,22 @@ void EcuDialog::on_comboBoxInterface_currentIndexChanged(int index)
             ui->comboBoxUDP_mcastaddress->setEnabled(ui->checkBoxMulticast->isChecked());
             break;
 
-        case EcuItem::INTERFACETYPE_SERIAL:
+        case EcuItem::INTERFACETYPE_SERIAL_DLT:
             ui->tabWidget->setTabEnabled(1,false);
             ui->tabWidget->setTabEnabled(2,false);
             ui->tabWidget->setTabEnabled(3,true);
+            ui->checkBoxSendSerialHeaderSerial->setVisible(true);
+            ui->checkBoxSyncToSerialHeaderSerial->setVisible(true);
             break;
+
+        case EcuItem::INTERFACETYPE_SERIAL_ASCII:
+            ui->tabWidget->setTabEnabled(1,false);
+            ui->tabWidget->setTabEnabled(2,false);
+            ui->tabWidget->setTabEnabled(3,true);
+            ui->checkBoxSendSerialHeaderSerial->setVisible(false);
+            ui->checkBoxSyncToSerialHeaderSerial->setVisible(false);
+            break;
+
     }
 }
 

--- a/src/ecudialog.ui
+++ b/src/ecudialog.ui
@@ -52,17 +52,22 @@
         <widget class="QComboBox" name="comboBoxInterface">
          <item>
           <property name="text">
-           <string>TCP</string>
+           <string>TCP DLT</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>UDP</string>
+           <string>UDP DLT</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Serial</string>
+           <string>Serial DLT</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Serial ASCII</string>
           </property>
          </item>
         </widget>

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -129,7 +129,8 @@ void EcuItem::update()
             }
             socket = & udpsocket;
             break;
-        case EcuItem::INTERFACETYPE_SERIAL:
+        case EcuItem::INTERFACETYPE_SERIAL_DLT:
+        case EcuItem::INTERFACETYPE_SERIAL_ASCII:
             setData(1,Qt::DisplayRole,QString("%1 [%2]").arg(description).arg(port));
             socket = 0;
             break;

--- a/src/project.h
+++ b/src/project.h
@@ -63,7 +63,8 @@ public:
     enum {
         INTERFACETYPE_TCP,
         INTERFACETYPE_UDP,
-        INTERFACETYPE_SERIAL
+        INTERFACETYPE_SERIAL_DLT,
+        INTERFACETYPE_SERIAL_ASCII
     };
 
     EcuItem(QTreeWidgetItem *parent = 0);

--- a/src/version.h
+++ b/src/version.h
@@ -23,7 +23,7 @@
 /* changing minor & major when layout of settings file config.ini changes */
 /* this kind of change is tracked in the settings dialogr */
 /* for other bugfixes and not major feature enhancement just use patch level */
-#define PACKAGE_VERSION_STATE "release"
+#define PACKAGE_VERSION_STATE "testversion"
 #define PACKAGE_MAJOR_VERSION "2"
 #define PACKAGE_MINOR_VERSION "21"
 #define PACKAGE_PATCH_LEVEL "0"


### PR DESCRIPTION
Provide a new connection type "Serial ASCII" for serial ASCII terminals. All received lines over a serial line are converted and written into DLT message into the currently opened DLT file. Select Interface Type "Serial ASCII" in the ECU configuration.

Signed-off-by: Alexander Wenzel <Alexander.AW.Wenzel@bmw.de>