### PR TITLE
proposal: use monospace font for table view cells

### DIFF
--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -341,6 +341,11 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
         }
     }
 
+     if ( role == Qt::FontRole )
+     {
+         return QFont("Hack", 10);
+     }
+
      return QVariant();
  }
 


### PR DESCRIPTION
Just as a proposal: Use a monospace font in the table view.

Unfortunately this is a quick'n'dirty PR. Before merging this at least a universally available monospace font should be chosen.

For our logging we use fixed-width identifiers at the start of each line and currently the actual message begins at a different position in each line due to the non-monospace font, which is hard to read and to keep the overview.