### PR TITLE
Keep windows artifacts

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -107,6 +107,14 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: DLT-Mac
+      - name: Download DLT Windows parser artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: DLT-Windows-parser
+      - name: Download DLT Windows sdk artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: DLT-Windows-sdk
       - run: |
           assetsZip=$(find . -name 'DLT*.zip' | while read -r asset ; do echo "-a $asset" ; done)
           VERSION=$(echo $VERSION | cut -d'/' -f3)


### PR DESCRIPTION
With this pull request the Windows artifacts are kept as well

https://github.com/hannesa2/dlt-viewer/releases/tag/v2.21.2.0

![image](https://user-images.githubusercontent.com/3314607/112593972-86f4ba00-8e08-11eb-9b34-d9ac4dfcc70f.png)
