### PR TITLE
Minor refactoring at mainwindow and DltExporter 

### DIFF
--- a/src/dltexporter.cpp
+++ b/src/dltexporter.cpp
@@ -162,6 +162,12 @@ bool DltExporter::finish()
     {
         /* export to clipboard */
         QClipboard *clipboard = QApplication::clipboard();
+
+        /*remove '\n' from the string*/
+        if (clipboardString.endsWith('\n'))
+        {
+            clipboardString.resize(clipboardString.size() - 1);
+        }
         clipboard->setText(clipboardString);
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2011,6 +2011,11 @@ void MainWindow::on_actionFindNext()
            list.append(searchTextbox->text());
        }
     QString title = "Search Results";
+
+    if ( 0 < m_searchtableModel->get_SearchResultListSize())
+    {
+        title = QString("Search Results: %L1").arg(m_searchtableModel->get_SearchResultListSize());
+    }
     ui->dockWidgetSearchIndex->setWindowTitle(title);
     ui->dockWidgetSearchIndex->show();
     m_CompleterModel.setStringList(list);


### PR DESCRIPTION
### Remove '\n' from the end of the clipboard string
- Allow the user to use the copied payload directly without the need to remove the newline every time.
- The payload of a message can be used to search in code or in DLT logs.

### Add results count to dockWidgetSearchIndex title
- The title of the search results window doesn't contain results count when the search is triggered from the icon buttons next to the search text box.
- Somehow the signals are triggered differently when the search is triggered from the icon buttons.